### PR TITLE
Fix memory leaks in two `pnf_handle_*()` functions

### DIFF
--- a/open-nFAPI/pnf/src/pnf_p7.c
+++ b/open-nFAPI/pnf/src/pnf_p7.c
@@ -1591,8 +1591,9 @@ void pnf_handle_dl_tti_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_p7)
 	else
 	{
 		NFAPI_TRACE(NFAPI_TRACE_ERROR, "Failed to unpack dl_tti_req");
-		deallocate_nfapi_dl_tti_request(req, pnf_p7);
 	}
+
+	deallocate_nfapi_dl_tti_request(req, pnf_p7);
 }
 
 void pnf_handle_dl_config_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_p7)
@@ -1998,8 +1999,10 @@ void pnf_handle_tx_data_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_p7
 	}
 	else
 	{
-		deallocate_nfapi_tx_data_request(req, pnf_p7);
+		NFAPI_TRACE(NFAPI_TRACE_ERROR, "Failed to unpack tx_data_req");
 	}
+
+	deallocate_nfapi_tx_data_request(req, pnf_p7);
 }
 
 void pnf_handle_tx_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_p7)


### PR DESCRIPTION
When running the proxy in 5G/SA mode, the process would leak memory to the point that Linux would kill the process after 1-2mins.

This PR frees the two largest leaks (there are more). At least using top, there is no noticeable increase in memory.

I checked using `valgrind`. It is unclear to me why asan does not flag this.