### PR TITLE
Episys/mel/nfapi bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ sudo -E ./ran_build/build/nr-uesoftmodem -O ../ci-scripts/conf_files/episci/prox
 
 - nrUE NODE_ID starts from 2 from the first nrUE. If you run one more nrUE, the
 - next NODE_ID = 3 in additional terminal.
+- IMSI config should match 5GCN configuration ($imsi)
 
 ```shell
 cd .../openairinterface5g
@@ -228,7 +229,8 @@ cd cmake_targets
 node_id=2
 sudo -E ./ran_build/build/nr-uesoftmodem -O ../ci-scripts/conf_files/episci/proxy_nr-ue.nfapi.conf --nokrnmod 1 \
 --ue-idx-standalone $node_id --nfapi 5 --node-number $node_id --emulate-l1 --nsa \
---log_config.global_log_options level,nocolor,time,thread_id | tee nrue_$node_id.log 2>&1
+--log_config.global_log_options level,nocolor,time,thread_id | tee nrue_$node_id.log 2>&1 \
+--uicc0.imsi $imsi
 ```
 
 ### 5. Open a terminal and launch UE ###

--- a/open-nFAPI/nfapi/public_inc/nfapi_nr_interface_scf.h
+++ b/open-nFAPI/nfapi/public_inc/nfapi_nr_interface_scf.h
@@ -1312,7 +1312,7 @@ typedef struct
   uint8_t  comb_offset;//Transmission comb offset 𝑘 ̄ TC [TS38.211, Sec 6.4.1.4.3] Value: 0 → 1 (combSize = 0) Value: 0 → 3 (combSize = 1)
   uint8_t  cyclic_shift;
   uint8_t  frequency_position;
-  uint8_t  frequency_shift;
+  uint16_t frequency_shift;
   uint8_t  frequency_hopping;
   uint8_t  group_or_sequence_hopping;//Group or sequence hopping configuration (RRC parameter groupOrSequenceHopping in SRS-Resource
   uint8_t  resource_type;//Type of SRS resource allocation

--- a/open-nFAPI/nfapi/src/nfapi_p7.c
+++ b/open-nFAPI/nfapi/src/nfapi_p7.c
@@ -3053,7 +3053,7 @@ static uint8_t pack_nr_rx_data_indication(void *msg, uint8_t **ppWritePackedMsg,
 
 	for (int i = 0; i < pNfapiMsg->number_of_pdus; i++)
 	{
-		if(!pack_nr_rx_data_indication_body(&(pNfapiMsg->pdu_list[i]), ppWritePackedMsg, end))	
+		if(!pack_nr_rx_data_indication_body(&(pNfapiMsg->pdu_list[i]), ppWritePackedMsg, end))
 		        return 0;
 	}
 
@@ -3402,6 +3402,7 @@ int nfapi_nr_p7_message_pack(void *pMessageBuf, void *pPackedBuf, uint32_t packe
 
 		case NFAPI_NR_PHY_MSG_TYPE_SLOT_INDICATION:
 			result = pack_nr_slot_indication(pMessageHeader, &pWritePackedMessage, end, config);
+			break;
 
 		case NFAPI_NR_PHY_MSG_TYPE_RX_DATA_INDICATION:
 			result = pack_nr_rx_data_indication(pMessageHeader, &pWritePackedMessage, end, config);

--- a/open-nFAPI/nfapi/src/nfapi_p7.c
+++ b/open-nFAPI/nfapi/src/nfapi_p7.c
@@ -1048,7 +1048,7 @@ static uint8_t pack_ul_tti_request_srs_pdu(nfapi_nr_srs_pdu_t *srs_pdu, uint8_t 
           push8(srs_pdu->comb_offset, ppWritePackedMsg, end) &&
           push8(srs_pdu->cyclic_shift, ppWritePackedMsg, end) &&
           push8(srs_pdu->frequency_position, ppWritePackedMsg, end) &&
-          push8(srs_pdu->frequency_shift, ppWritePackedMsg, end) &&
+          push16(srs_pdu->frequency_shift, ppWritePackedMsg, end) &&
           push8(srs_pdu->frequency_hopping, ppWritePackedMsg, end) &&
           push8(srs_pdu->group_or_sequence_hopping, ppWritePackedMsg, end) &&
           push8(srs_pdu->resource_type, ppWritePackedMsg, end) &&
@@ -3022,10 +3022,8 @@ return 1;
 
 //RX DATA INDICATION
 
-static uint8_t pack_nr_rx_data_indication_body(void* tlv, uint8_t **ppWritePackedMsg, uint8_t *end)
+static uint8_t pack_nr_rx_data_indication_body(nfapi_nr_rx_data_pdu_t *value, uint8_t **ppWritePackedMsg, uint8_t *end)
 {
-	nfapi_nr_rx_data_pdu_t* value = (nfapi_nr_rx_data_pdu_t*)tlv;
-
 	if(!(push32(value->handle, ppWritePackedMsg, end) &&
 	 	 push16(value->rnti, ppWritePackedMsg, end) &&
 		 push8(value->harq_id, ppWritePackedMsg, end) &&
@@ -3055,7 +3053,7 @@ static uint8_t pack_nr_rx_data_indication(void *msg, uint8_t **ppWritePackedMsg,
 
 	for (int i = 0; i < pNfapiMsg->number_of_pdus; i++)
 	{
-		if(!pack_nr_rx_data_indication_body(&(pNfapiMsg->pdu_list[i]), ppWritePackedMsg, end))
+		if (!pack_nr_rx_data_indication_body(&pNfapiMsg->pdu_list[i], ppWritePackedMsg, end))
 		        return 0;
 	}
 
@@ -3103,10 +3101,8 @@ return 1;
 
 //SRS INDICATION
 
-static uint8_t pack_nr_srs_indication_body(void* tlv, uint8_t **ppWritePackedMsg, uint8_t *end)
+static uint8_t pack_nr_srs_indication_body(nfapi_nr_srs_indication_pdu_t *value, uint8_t **ppWritePackedMsg, uint8_t *end)
 {
-	nfapi_nr_srs_indication_pdu_t* value = (nfapi_nr_srs_indication_pdu_t*)tlv;
-
 	if(!(push32(value->handle, ppWritePackedMsg, end) &&
 	 	 push16(value->rnti, ppWritePackedMsg, end) &&
 		 push16(value->timing_advance, ppWritePackedMsg, end) &&
@@ -3118,8 +3114,7 @@ static uint8_t pack_nr_srs_indication_body(void* tlv, uint8_t **ppWritePackedMsg
 		  return 0;
 	for(int i = 0; i < value->reported_symbol_list->num_rbs; i++)
 	{
-		if(!(push8(value->reported_symbol_list->rb_list->rb_snr, ppWritePackedMsg, end)
-			))
+		if (!push8(value->reported_symbol_list->rb_list[i].rb_snr, ppWritePackedMsg, end))
 			return 0;
 	}
 	return 1;
@@ -3137,8 +3132,8 @@ static uint8_t pack_nr_srs_indication(void *msg, uint8_t **ppWritePackedMsg, uin
 
 	for(int i=0; i<pNfapiMsg->number_of_pdus;i++)
 	{
-		if(!pack_nr_srs_indication_body(&(pNfapiMsg->pdu_list[i]),ppWritePackedMsg,end))
-		return 0;
+		if (!pack_nr_srs_indication_body(&pNfapiMsg->pdu_list[i], ppWritePackedMsg, end))
+		        return 0;
 	}
 
 return 1;
@@ -3407,7 +3402,6 @@ int nfapi_nr_p7_message_pack(void *pMessageBuf, void *pPackedBuf, uint32_t packe
 
 		case NFAPI_NR_PHY_MSG_TYPE_SLOT_INDICATION:
 			result = pack_nr_slot_indication(pMessageHeader, &pWritePackedMessage, end, config);
-			break;
 
 		case NFAPI_NR_PHY_MSG_TYPE_RX_DATA_INDICATION:
 			result = pack_nr_rx_data_indication(pMessageHeader, &pWritePackedMessage, end, config);
@@ -4590,7 +4584,7 @@ static uint8_t unpack_ul_tti_request_srs_pdu(void *tlv, uint8_t **ppReadPackedMs
           pull8(ppReadPackedMsg, &srs_pdu->comb_offset, end) &&
           pull8(ppReadPackedMsg, &srs_pdu->cyclic_shift, end) &&
           pull8(ppReadPackedMsg, &srs_pdu->frequency_position, end) &&
-          pull8(ppReadPackedMsg, &srs_pdu->frequency_shift, end) &&
+          pull16(ppReadPackedMsg, &srs_pdu->frequency_shift, end) &&
           pull8(ppReadPackedMsg, &srs_pdu->frequency_hopping, end) &&
           pull8(ppReadPackedMsg, &srs_pdu->group_or_sequence_hopping, end) &&
           pull8(ppReadPackedMsg, &srs_pdu->resource_type, end) &&
@@ -5722,7 +5716,7 @@ static uint8_t unpack_nr_rx_data_indication_body(nfapi_nr_rx_data_pdu_t* value,
 		return 0;
 
         uint16_t length = value->pdu_length;
-        value->pdu = nfapi_p7_allocate(length, config);
+        value->pdu = nfapi_p7_allocate(sizeof(*value->pdu) * length, config);
 
         if (pullarray8(ppReadPackedMsg, value->pdu, length, length, end) == 0)
         {
@@ -5803,10 +5797,8 @@ return 1;
 
 //SRS INDICATION
 
-static uint8_t unpack_nr_srs_indication_body(void* tlv, uint8_t **ppReadPackedMsg, uint8_t *end)
+static uint8_t unpack_nr_srs_indication_body(nfapi_nr_srs_indication_pdu_t* value, uint8_t **ppReadPackedMsg, uint8_t *end)
 {
-	nfapi_nr_srs_indication_pdu_t* value = (nfapi_nr_srs_indication_pdu_t*)tlv;
-
 	if(!(pull32(ppReadPackedMsg, &value->handle, end) &&
 	 	 pull16(ppReadPackedMsg, &value->rnti, end) &&
 		 pull16(ppReadPackedMsg, &value->timing_advance, end) &&
@@ -5818,17 +5810,14 @@ static uint8_t unpack_nr_srs_indication_body(void* tlv, uint8_t **ppReadPackedMs
 		  return 0;
 	for(int i = 0; i < value->reported_symbol_list->num_rbs; i++)
 	{
-		if(!(pull8(ppReadPackedMsg, &value->reported_symbol_list->rb_list->rb_snr, end)
-			))
+		if (!pull8(ppReadPackedMsg, &value->reported_symbol_list->rb_list[i].rb_snr, end))
 			return 0;
 	}
 	return 1;
 }
 
-static uint8_t unpack_nr_srs_indication(uint8_t **ppReadPackedMsg, uint8_t *end, void *msg, nfapi_p7_codec_config_t* config)
+static uint8_t unpack_nr_srs_indication(uint8_t **ppReadPackedMsg, uint8_t *end, nfapi_nr_srs_indication_t *pNfapiMsg, nfapi_p7_codec_config_t* config)
 {
-	nfapi_nr_srs_indication_t *pNfapiMsg = (nfapi_nr_srs_indication_t*)msg;
-
 	if (!(pull16(ppReadPackedMsg,&pNfapiMsg->sfn , end) &&
 		pull16(ppReadPackedMsg,&pNfapiMsg->slot , end) &&
 		pull8(ppReadPackedMsg,&pNfapiMsg->number_of_pdus, end)
@@ -5837,7 +5826,7 @@ static uint8_t unpack_nr_srs_indication(uint8_t **ppReadPackedMsg, uint8_t *end,
 
 	for(int i=0; i<pNfapiMsg->number_of_pdus;i++)
 	{
-		if(!unpack_nr_srs_indication_body(&pNfapiMsg->pdu_list,ppReadPackedMsg,end))
+		if (!unpack_nr_srs_indication_body(&pNfapiMsg->pdu_list[i], ppReadPackedMsg, end))
 		return 0;
 	}
 

--- a/open-nFAPI/nfapi/src/nfapi_p7.c
+++ b/open-nFAPI/nfapi/src/nfapi_p7.c
@@ -3053,7 +3053,7 @@ static uint8_t pack_nr_rx_data_indication(void *msg, uint8_t **ppWritePackedMsg,
 
 	for (int i = 0; i < pNfapiMsg->number_of_pdus; i++)
 	{
-		if (!pack_nr_rx_data_indication_body(&pNfapiMsg->pdu_list[i], ppWritePackedMsg, end))
+		if(!pack_nr_rx_data_indication_body(&(pNfapiMsg->pdu_list[i]), ppWritePackedMsg, end))	
 		        return 0;
 	}
 


### PR DESCRIPTION
    Updating nfapi code to match OAI with bug fixes

    The nfapi bug fixes include properly indexing
    through the SR indications, properly allocating
    the rx_indication, and handling truncated msgs.

    Also, updating the README to remove multiple
    conf files when running in EPC/5GCN mode.
