### PR TITLE
Virtual time support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -38,6 +38,7 @@ SRCS = \
 	$(SRC_DIR)/nfapiutils.c \
 	$(SRC_DIR)/nfapi_pnf.c \
 	$(SRC_DIR)/queue.c \
+	$(SRC_DIR)/ss_proxy.c \
 	$(LIB_SOURCES)
 
 OBJS := $(SRCS:%=$(BUILD_DIR)/%.o)

--- a/open-nFAPI/nfapi/public_inc/nfapi_interface.h
+++ b/open-nFAPI/nfapi/public_inc/nfapi_interface.h
@@ -209,6 +209,7 @@ typedef enum {
 	NFAPI_NMM_STOP_RESPONSE,
 
 	NFAPI_VENDOR_EXT_MSG_MIN = 0x0300,
+	P7_CELL_SEARCH_IND = 0x0304,
 	NFAPI_VENDOR_EXT_MSG_MAX = 0x03FF,
 
 
@@ -3562,6 +3563,17 @@ typedef struct {
 	uint32_t error_code;
 	nfapi_vendor_extension_tlv_t vendor_extension;
 } nfapi_ue_release_response_t;
+
+/**
+ * TODO: Handling only LTE cell indication, should add NR also.
+ */
+typedef struct {
+        nfapi_p7_message_header_t header;
+        uint32_t error_code;
+        nfapi_lte_cell_search_indication_t lte_cell_search_indication;
+        nfapi_vendor_extension_tlv_t vendor_extension;
+} vendor_nfapi_cell_search_indication_t;
+
 
 // 
 // P4 Messages

--- a/open-nFAPI/nfapi/src/nfapi_p7.c
+++ b/open-nFAPI/nfapi/src/nfapi_p7.c
@@ -40,6 +40,7 @@
 
 extern int nfapi_unpack_p7_vendor_extension(nfapi_p7_message_header_t *header, uint8_t **ppReadPackedMsg, void *user_data);
 extern int nfapi_pack_p7_vendor_extension(nfapi_p7_message_header_t *header, uint8_t **ppWritePackedMsg, void *user_data);
+static uint8_t pack_p7_cell_search_indication(void *msg, uint8_t **ppWritePackedMsg, uint8_t *end, nfapi_p7_codec_config_t* config);
 
 uint32_t nfapi_calculate_checksum(uint8_t *buffer, uint16_t len) {
   uint32_t chksum = 0;
@@ -804,7 +805,7 @@ static uint8_t pack_dl_tti_request(void *msg, uint8_t **ppWritePackedMsg, uint8_
 		return 0;
 	}
 
-	for(int i=0;i<pNfapiMsg->dl_tti_request_body.nPDUs;i++)	
+	for(int i=0;i<pNfapiMsg->dl_tti_request_body.nPDUs;i++)
 	{
 		if(!pack_dl_tti_request_body_value(&pNfapiMsg->dl_tti_request_body.dl_tti_pdu_list[i],ppWritePackedMsg,end))
 		return 0;
@@ -3441,13 +3442,20 @@ int nfapi_nr_p7_message_pack(void *pMessageBuf, void *pPackedBuf, uint32_t packe
 				if(pMessageHeader->message_id >= NFAPI_VENDOR_EXT_MSG_MIN &&
 				   pMessageHeader->message_id <= NFAPI_VENDOR_EXT_MSG_MAX)
 				{
-					if(config && config->pack_p7_vendor_extension)
+					if (pMessageHeader->message_id == P7_CELL_SEARCH_IND)
 					{
-						result = (config->pack_p7_vendor_extension)(pMessageHeader, &pWritePackedMessage, end, config);
+						result = pack_p7_cell_search_indication(pMessageHeader, &pWritePackedMessage, end, config);
 					}
 					else
 					{
-						NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve ecoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+						if(config && config->pack_p7_vendor_extension)
+						{
+							result = (config->pack_p7_vendor_extension)(pMessageHeader, &pWritePackedMessage, end, config);
+						}
+						else
+						{
+							NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve ecoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+						}
 					}
 				}
 				else
@@ -3495,6 +3503,42 @@ int nfapi_nr_p7_message_pack(void *pMessageBuf, void *pPackedBuf, uint32_t packe
 	}
 
 	return (packedMsgLen);
+}
+
+static uint8_t pack_subframe_indication(void *msg, uint8_t **ppWritePackedMsg, uint8_t *end, nfapi_p7_codec_config_t* config)
+{
+        nfapi_subframe_indication_t *pNfapiMsg = (nfapi_subframe_indication_t*)msg;
+        return (push16(pNfapiMsg->sfn_sf, ppWritePackedMsg, end));
+}
+
+static uint8_t pack_p7_lte_cell_search_indication_value(void *msg, uint8_t **ppWritePackedMsg, uint8_t *end)
+{
+        nfapi_lte_cell_search_indication_t* value = (nfapi_lte_cell_search_indication_t*)msg;
+        uint16_t idx = 0;
+
+        if(push16(value->number_of_lte_cells_found, ppWritePackedMsg, end) == 0)
+                return 0;
+
+        for(idx = 0; idx < value->number_of_lte_cells_found; ++idx)
+        {
+                if(!(push16(value->lte_found_cells[idx].pci, ppWritePackedMsg, end) &&
+                         push8(value->lte_found_cells[idx].rsrp, ppWritePackedMsg, end) &&
+                         push8(value->lte_found_cells[idx].rsrq, ppWritePackedMsg, end) &&
+                         pushs16(value->lte_found_cells[idx].frequency_offset, ppWritePackedMsg, end)))
+                        return 0;
+        }
+        return 1;
+}
+
+
+static uint8_t pack_p7_cell_search_indication(void *msg, uint8_t **ppWritePackedMsg, uint8_t *end, nfapi_p7_codec_config_t* config)
+{
+        vendor_nfapi_cell_search_indication_t *pNfapiMsg = (vendor_nfapi_cell_search_indication_t*)msg;
+
+        return (push32(pNfapiMsg->error_code, ppWritePackedMsg, end) &&
+                        pack_tlv(NFAPI_LTE_CELL_SEARCH_INDICATION_TAG, &pNfapiMsg->lte_cell_search_indication, ppWritePackedMsg, end, &pack_p7_lte_cell_search_indication_value) &&
+                        pack_p7_vendor_extension_tlv(pNfapiMsg->vendor_extension, ppWritePackedMsg, end, config));
+
 }
 
 int nfapi_p7_message_pack(void *pMessageBuf, void *pPackedBuf, uint32_t packedBufLen, nfapi_p7_codec_config_t *config) {
@@ -3609,14 +3653,21 @@ int nfapi_p7_message_pack(void *pMessageBuf, void *pPackedBuf, uint32_t packedBu
     case NFAPI_TIMING_INFO:
       result = pack_timing_info(pMessageHeader, &pWritePackedMessage, end, config);
       break;
+    case NFAPI_SUBFRAME_INDICATION:
+      result = pack_subframe_indication(pMessageHeader, &pWritePackedMessage, end, config);
+      break;
 
     default: {
       if(pMessageHeader->message_id >= NFAPI_VENDOR_EXT_MSG_MIN &&
           pMessageHeader->message_id <= NFAPI_VENDOR_EXT_MSG_MAX) {
-        if(config && config->pack_p7_vendor_extension) {
-          result = (config->pack_p7_vendor_extension)(pMessageHeader, &pWritePackedMessage, end, config);
+        if (pMessageHeader->message_id == P7_CELL_SEARCH_IND) {
+          result = pack_p7_cell_search_indication(pMessageHeader, &pWritePackedMessage, end, config);
         } else {
-          NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve ecoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+          if(config && config->pack_p7_vendor_extension) {
+            result = (config->pack_p7_vendor_extension)(pMessageHeader, &pWritePackedMessage, end, config);
+          } else {
+            NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve ecoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+          }
         }
       } else {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s NFAPI Unknown message ID %d\n", __FUNCTION__, pMessageHeader->message_id);
@@ -7410,7 +7461,55 @@ static uint8_t unpack_nr_timing_info(uint8_t **ppReadPackedMsg, uint8_t *end, vo
           unpack_p7_tlv_list(NULL, 0, ppReadPackedMsg, end, config, &pNfapiMsg->vendor_extension));
 }
 
+static uint8_t unpack_subframe_indication(uint8_t **ppReadPackedMsg, uint8_t *end, void *msg, nfapi_p7_codec_config_t* config)
+{
+        nfapi_subframe_indication_t *pNfapiMsg = (nfapi_subframe_indication_t *)msg;
 
+        if (!(pull16(ppReadPackedMsg, &pNfapiMsg->sfn_sf , end) ))
+                return 0;
+
+        return 1;
+}
+
+static uint8_t unpack_p7_lte_cell_search_indication_value(void *tlv, uint8_t **ppReadPackedMsg, uint8_t *end, nfapi_p7_codec_config_t* config)
+{
+	nfapi_lte_cell_search_indication_t* value = (nfapi_lte_cell_search_indication_t*)tlv;
+
+	uint16_t idx = 0;
+	if(pull16(ppReadPackedMsg, &value->number_of_lte_cells_found, end) == 0)
+		return 0;
+
+	if(value->number_of_lte_cells_found <= NFAPI_MAX_LTE_CELLS_FOUND)
+	{
+		for(idx = 0; idx < value->number_of_lte_cells_found; ++idx)
+		{
+			if(!(pull16(ppReadPackedMsg, &value->lte_found_cells[idx].pci, end) &&
+				 pull8(ppReadPackedMsg, &value->lte_found_cells[idx].rsrp, end) &&
+				 pull8(ppReadPackedMsg, &value->lte_found_cells[idx].rsrq, end) &&
+				 pulls16(ppReadPackedMsg, &value->lte_found_cells[idx].frequency_offset, end)))
+				return 0;
+		}
+	}
+	else
+	{
+		NFAPI_TRACE(NFAPI_TRACE_ERROR, "More found LTE cells than we can decode %d \n", value->number_of_lte_cells_found);
+		return 0;
+	}
+	return 1;
+}
+
+static uint8_t unpack_p7_cell_search_indication(uint8_t **ppReadPackedMsg, uint8_t *end, void *msg, nfapi_p7_codec_config_t* config)
+{
+	vendor_nfapi_cell_search_indication_t *pNfapiMsg = (vendor_nfapi_cell_search_indication_t*)msg;
+
+	unpack_p7_tlv_t unpack_fns[] =
+	{
+		{ NFAPI_LTE_CELL_SEARCH_INDICATION_TAG, &pNfapiMsg->lte_cell_search_indication, &unpack_p7_lte_cell_search_indication_value},
+	};
+
+	return (pull32(ppReadPackedMsg, &pNfapiMsg->error_code, end) &&
+			unpack_p7_tlv_list(unpack_fns, sizeof(unpack_fns)/sizeof(unpack_tlv_t), ppReadPackedMsg, end, config, &pNfapiMsg->vendor_extension));
+}
 
 // unpack length check
 
@@ -7880,16 +7979,35 @@ int nfapi_p7_message_unpack(void *pMessageBuf, uint32_t messageBufLen, void *pUn
         return -1;
 
       break;
+    case NFAPI_SUBFRAME_INDICATION:
+      if (check_unpack_length(NFAPI_SUBFRAME_INDICATION, unpackedBufLen)){
+        nfapi_subframe_indication_t* msg = (nfapi_subframe_indication_t*) pMessageHeader;
+        result = unpack_subframe_indication(&pReadPackedMessage,  end, msg, config);
+      }
+      else
+        return -1;
+      break;
 
     default:
       if(pMessageHeader->message_id >= NFAPI_VENDOR_EXT_MSG_MIN &&
-          pMessageHeader->message_id <= NFAPI_VENDOR_EXT_MSG_MAX) {
-        if(config && config->unpack_p7_vendor_extension) {
-          result = (config->unpack_p7_vendor_extension)(pMessageHeader, &pReadPackedMessage, end, config);
-        } else {
-          NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve decoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+          pMessageHeader->message_id <= NFAPI_VENDOR_EXT_MSG_MAX)
+      {
+        if ( pMessageHeader->message_id == P7_CELL_SEARCH_IND )
+		{
+          result = unpack_p7_cell_search_indication(&pReadPackedMessage, end, pMessageHeader, config);
+          break;
         }
-      } else {
+        else
+        {
+          if(config && config->unpack_p7_vendor_extension)
+          {
+            result = (config->unpack_p7_vendor_extension)(pMessageHeader, &pReadPackedMessage, end, config);
+          } else {
+            NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve decoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+          }
+        }
+      } 
+      else {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s NFAPI Unknown message ID %d\n", __FUNCTION__, pMessageHeader->message_id);
       }
 
@@ -8077,13 +8195,21 @@ int nfapi_nr_p7_message_unpack(void *pMessageBuf, uint32_t messageBufLen, void *
 			if(pMessageHeader->message_id >= NFAPI_VENDOR_EXT_MSG_MIN &&
 			   pMessageHeader->message_id <= NFAPI_VENDOR_EXT_MSG_MAX)
 			{
-				if(config && config->unpack_p7_vendor_extension)
+				if ( pMessageHeader->message_id == P7_CELL_SEARCH_IND )
 				{
-					result = (config->unpack_p7_vendor_extension)(pMessageHeader, &pReadPackedMessage, end, config);
+					result = unpack_p7_cell_search_indication(&pReadPackedMessage, end, pMessageHeader, config);
+					break;
 				}
 				else
 				{
-					NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve decoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+					if(config && config->unpack_p7_vendor_extension)
+					{
+						result = (config->unpack_p7_vendor_extension)(pMessageHeader, &pReadPackedMessage, end, config);
+					}
+					else
+					{
+						NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s VE NFAPI message ID %d. No ve decoder provided\n", __FUNCTION__, pMessageHeader->message_id);
+					}
 				}
 			}
 			else

--- a/open-nFAPI/pnf/inc/pnf_p7.h
+++ b/open-nFAPI/pnf/inc/pnf_p7.h
@@ -150,8 +150,9 @@ int pnf_nr_p7_message_pump(pnf_p7_t* pnf_p7);
 int pnf_p7_pack_and_send_p7_message(pnf_p7_t* pnf_p7, nfapi_p7_message_header_t* msg, uint32_t msg_len);
 int pnf_nr_p7_pack_and_send_p7_message(pnf_p7_t* pnf_p7, nfapi_p7_message_header_t* header, uint32_t msg_len);
 int pnf_p7_send_message(pnf_p7_t* pnf_p7, uint8_t* msg, uint32_t msg_len);
+void pnf_handle_p7_message(void *pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_p7,  uint32_t rx_hr_time);
 
-
+int pnf_p7_ue_subframe_ind(pnf_p7_t* pnf_p7,uint16_t phy_id,uint16_t sfn_sf, uint16_t sfn_sf_sync);
 int pnf_p7_slot_ind(pnf_p7_t* config, uint16_t phy_id, uint16_t sfn, uint16_t slot);
 int pnf_p7_subframe_ind(pnf_p7_t* config, uint16_t phy_id, uint16_t sfn_sf);
 

--- a/open-nFAPI/pnf/public_inc/nfapi_pnf_interface.h
+++ b/open-nFAPI/pnf/public_inc/nfapi_pnf_interface.h
@@ -897,6 +897,9 @@ int nfapi_pnf_p7_nr_rach_ind(nfapi_pnf_p7_config_t* config, nfapi_nr_rach_indica
 int nfapi_pnf_p7_vendor_extension(nfapi_pnf_p7_config_t* config, nfapi_p7_message_header_t* msg);
 
 int nfapi_pnf_ue_release_resp(nfapi_pnf_p7_config_t* config, nfapi_ue_release_response_t* resp);
+
+int nfapi_pnf_p7_ue_subframe_ind(nfapi_pnf_p7_config_t* config, uint16_t phy_id, uint16_t sfn_sf, uint16_t sfn_sf_sync);
+
 #if defined(__cplusplus)
 }
 #endif

--- a/open-nFAPI/pnf/public_inc/nfapi_pnf_interface.h
+++ b/open-nFAPI/pnf/public_inc/nfapi_pnf_interface.h
@@ -900,6 +900,12 @@ int nfapi_pnf_ue_release_resp(nfapi_pnf_p7_config_t* config, nfapi_ue_release_re
 
 int nfapi_pnf_p7_ue_subframe_ind(nfapi_pnf_p7_config_t* config, uint16_t phy_id, uint16_t sfn_sf, uint16_t sfn_sf_sync);
 
+/*! Send a cell search indication message
+ * \param config A pointer to a PNF P7 config
+ * \param ind A pointer to the cell search indication message structure
+ * \return 0 means success, -1 means failure
+ */
+int nfapi_pnf_p7_cell_search_ind(nfapi_pnf_p7_config_t* config, vendor_nfapi_cell_search_indication_t* ind);
 #if defined(__cplusplus)
 }
 #endif

--- a/open-nFAPI/pnf/src/pnf_p7_interface.c
+++ b/open-nFAPI/pnf/src/pnf_p7_interface.c
@@ -188,6 +188,17 @@ int nfapi_pnf_p7_sr_ind(nfapi_pnf_p7_config_t* config, nfapi_sr_indication_t* in
 	pnf_p7_t* _this = (pnf_p7_t*)(config);
 	return pnf_p7_pack_and_send_p7_message(_this, (nfapi_p7_message_header_t*)ind, sizeof(nfapi_sr_indication_t));
 }
+
+int nfapi_pnf_p7_ue_subframe_ind(nfapi_pnf_p7_config_t* config, uint16_t phy_id, uint16_t sfn_sf, uint16_t sfn_sf_sync)
+{
+        // Verify that config is not null
+        if(config == 0)
+                return -1;
+
+        pnf_p7_t* _this = (pnf_p7_t*)(config);
+
+        return pnf_p7_ue_subframe_ind(_this, phy_id, sfn_sf, sfn_sf_sync);
+}
 int nfapi_pnf_p7_cqi_ind(nfapi_pnf_p7_config_t* config, nfapi_cqi_indication_t* ind)
 {
 	if(config == NULL || ind == NULL)

--- a/open-nFAPI/pnf/src/pnf_p7_interface.c
+++ b/open-nFAPI/pnf/src/pnf_p7_interface.c
@@ -189,6 +189,19 @@ int nfapi_pnf_p7_sr_ind(nfapi_pnf_p7_config_t* config, nfapi_sr_indication_t* in
 	return pnf_p7_pack_and_send_p7_message(_this, (nfapi_p7_message_header_t*)ind, sizeof(nfapi_sr_indication_t));
 }
 
+int nfapi_pnf_p7_cell_search_ind(nfapi_pnf_p7_config_t* config, vendor_nfapi_cell_search_indication_t* ind)
+{
+        if (config == NULL || ind == NULL)
+        {
+                NFAPI_TRACE(NFAPI_TRACE_ERROR, "%s: NULL parameters\n", __FUNCTION__);
+                return -1;
+        }
+
+        pnf_p7_t* _this = (pnf_p7_t*)(config);
+
+        return pnf_p7_pack_and_send_p7_message(_this, &(ind->header), sizeof(vendor_nfapi_cell_search_indication_t));
+}
+
 int nfapi_pnf_p7_ue_subframe_ind(nfapi_pnf_p7_config_t* config, uint16_t phy_id, uint16_t sfn_sf, uint16_t sfn_sf_sync)
 {
         // Verify that config is not null

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -46,7 +46,7 @@ void Multi_UE_Proxy::start(softmodem_mode_t softmodem_mode)
 
     configure_nfapi_pnf(vnf_ipaddr.c_str(), vnf_p5port, pnf_ipaddr.c_str(), pnf_p7port, vnf_p7port);
 
-    if (ss_cfg_g->cfg.vt_enabled) {
+    if (NULL != ss_cfg_g && ss_cfg_g->cfg.vt_enabled) {
         if (pthread_create(&thread, NULL, &oai_subframe_task_vt, (void *)softmodem_mode) != 0)
         {
             NFAPI_TRACE(NFAPI_TRACE_ERROR, "pthread_create failed for calling oai_subframe_task_vt");

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -22,6 +22,7 @@
 #include <sstream>
 #include "lte_proxy.h"
 #include "nfapi_pnf.h"
+#include "proxy_ss_interface.h"
 
 namespace
 {
@@ -45,9 +46,16 @@ void Multi_UE_Proxy::start(softmodem_mode_t softmodem_mode)
 
     configure_nfapi_pnf(vnf_ipaddr.c_str(), vnf_p5port, pnf_ipaddr.c_str(), pnf_p7port, vnf_p7port);
 
-    if (pthread_create(&thread, NULL, &oai_subframe_task, (void *)softmodem_mode) != 0)
-    {
-        NFAPI_TRACE(NFAPI_TRACE_ERROR, "pthread_create failed for calling oai_subframe_task");
+    if (ss_cfg_g->cfg.vt_enabled) {
+        if (pthread_create(&thread, NULL, &oai_subframe_task_vt, (void *)softmodem_mode) != 0)
+        {
+            NFAPI_TRACE(NFAPI_TRACE_ERROR, "pthread_create failed for calling oai_subframe_task_vt");
+        }
+    } else {
+        if (pthread_create(&thread, NULL, &oai_subframe_task, (void *)softmodem_mode) != 0)
+        {
+            NFAPI_TRACE(NFAPI_TRACE_ERROR, "pthread_create failed for calling oai_subframe_task");
+        }
     }
 
     for (int i = 0; i < num_ues; i++)
@@ -190,6 +198,7 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(void *msg_org)
         nfapi_tx_request_t tx_req;
         nfapi_hi_dci0_request_t hi_dci0_req;
         nfapi_ul_config_request_t ul_config_req;
+        vendor_nfapi_cell_search_indication_t cell_info;
     } msg;
 
     if (nfapi_p7_message_unpack((void *)buffer, encoded_size, &msg, sizeof(msg), NULL) != 0)
@@ -259,6 +268,18 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(void *msg_org)
                 NFAPI_TRACE(NFAPI_TRACE_INFO , "NFAPI_HI_DCI0_REQ forwarded to UE from UE NEM: %u", id_);
             }
             break;
+        case P7_CELL_SEARCH_IND:
+            assert(ue_tx_socket[ue_idx] > 2);
+            if (sendto(ue_tx_socket[ue_idx], buffer, encoded_size, 0, (const struct sockaddr *) &address_tx_, sizeof(address_tx_)) < 0)
+            {
+                NFAPI_TRACE(NFAPI_TRACE_ERROR, "Send P7_CELL_SRCH_IND to OAI UE failed");
+            }
+            else
+            {
+                NFAPI_TRACE(NFAPI_TRACE_INFO , "P7_CELL_SRCH_IND forwarded to UE from UE NEM: %u", id_);
+            }
+            break;
+
 
         default:
             NFAPI_TRACE(NFAPI_TRACE_INFO , "Unhandled message at UE NEM: %d message_id: %u", id_, msg.header.message_id);

--- a/src/nfapi_pnf.h
+++ b/src/nfapi_pnf.h
@@ -238,7 +238,9 @@ void handle_nr_nfapi_ssb_pdu(PHY_VARS_gNB *gNB,int frame,int slot,
                              nfapi_nr_dl_tti_request_pdu_t *dl_tti_pdu);
 
 void *oai_subframe_task(void *context);
+void *oai_subframe_task_vt(void *context);
 void *oai_slot_task(void *context);
+void *oai_slot_task_vt(void *context);
 void oai_subframe_init();
 void oai_slot_init();
 void oai_subframe_flush_msgs_from_ue();

--- a/src/nfapiutils.c
+++ b/src/nfapiutils.c
@@ -51,6 +51,7 @@ const char *nfapi_get_message_id(const void *msg, size_t length)
     case NFAPI_RX_CQI_INDICATION: return "CQI";
     case NFAPI_HARQ_INDICATION: return "HARQ";
     case NFAPI_RX_SR_INDICATION: return "SR";
+    case NFAPI_SUBFRAME_INDICATION: return "SFNSF";
     case 0: return "Dummy";
     default:
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "Message_id is unknown %u", message_id);
@@ -74,6 +75,7 @@ const char *nfapi_nr_get_message_id(const void *msg, size_t length)
     case NFAPI_NR_PHY_MSG_TYPE_RX_DATA_INDICATION: return "RX_DATA_NR";
     case NFAPI_NR_PHY_MSG_TYPE_UCI_INDICATION: return "UCI_NR";
     case NFAPI_NR_PHY_MSG_TYPE_SRS_INDICATION: return "SRS_NR";
+    case NFAPI_NR_PHY_MSG_TYPE_SLOT_INDICATION: return "SLOT_NR";
     case 0: return "Dummy";
     default:
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "Message_id is unknown %u", message_id);
@@ -102,6 +104,7 @@ uint16_t nfapi_get_sfnsf(const void *msg, size_t length)
     case NFAPI_RX_CQI_INDICATION:
     case NFAPI_HARQ_INDICATION:
     case NFAPI_RX_SR_INDICATION:
+    case NFAPI_SUBFRAME_INDICATION:
     case 0:
         break;
     default:
@@ -139,6 +142,7 @@ uint16_t nfapi_get_sfnslot(const void *msg, size_t length)
     case NFAPI_NR_PHY_MSG_TYPE_RX_DATA_INDICATION:
     case NFAPI_NR_PHY_MSG_TYPE_UCI_INDICATION:
     case NFAPI_NR_PHY_MSG_TYPE_SRS_INDICATION:
+    case NFAPI_NR_PHY_MSG_TYPE_SLOT_INDICATION:
     case 0:
         break;
     default:

--- a/src/nr_proxy.cc
+++ b/src/nr_proxy.cc
@@ -262,6 +262,18 @@ void Multi_UE_NR_Proxy::oai_gnb_downlink_nfapi_task(void *msg_org)
                 NFAPI_TRACE(NFAPI_TRACE_INFO , "NFAPI_NR_PHY_MSG_TYPE_UL_DCI_REQUEST forwarded from Proxy to UE");
             }
             break;
+        case P7_CELL_SEARCH_IND:
+            assert(ue_tx_socket[ue_idx] > 2);
+            if (sendto(ue_tx_socket[ue_idx], buffer, encoded_size, 0, (const struct sockaddr *) &address_tx_, sizeof(address_tx_)) < 0)
+            {
+                NFAPI_TRACE(NFAPI_TRACE_ERROR, "Send P7_CELL_SRCH_IND to OAI UE failed");
+            }
+            else
+            {
+                NFAPI_TRACE(NFAPI_TRACE_INFO , "P7_CELL_SRCH_IND forwarded from Proxy to UE ");
+            }
+            break;
+
 
         default:
             NFAPI_TRACE(NFAPI_TRACE_INFO , "Unhandled message at Proxy message_id: %u", msg.header.message_id);

--- a/src/nr_proxy.cc
+++ b/src/nr_proxy.cc
@@ -192,6 +192,7 @@ void Multi_UE_NR_Proxy::oai_gnb_downlink_nfapi_task(void *msg_org)
         nfapi_nr_tx_data_request_t tx_data_req;
         nfapi_nr_ul_dci_request_t ul_dci_req;
         nfapi_nr_ul_tti_request_t ul_tti_request;
+        vendor_nfapi_cell_search_indication_t cell_info;
     } msg;
 
     if (nfapi_nr_p7_message_unpack((void *)buffer, encoded_size, &msg, sizeof(msg), NULL) != 0)

--- a/src/proxy_ss_interface.h
+++ b/src/proxy_ss_interface.h
@@ -1,0 +1,124 @@
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef _PROXY_SS_INTERFACE
+#define _PROXY_SS_INTERFACE
+
+#include "stdbool.h"
+
+/* Default Values of RSRP, RSRQ and Cell Search Periodicity */
+#define DEFAULT_CELL_RSRP 		40
+#define DEFAULT_CELL_RSRQ 		30
+#define DEFAULT_CELL_SRCH_PERIOD 	100
+
+typedef enum proxy_ss_message_id {
+  SS_ATTN_LIST     	= 1,
+  SS_ATTN_LIST_CNF 	= 2,
+  SS_CELL_CONFIG   	= 3,
+  SS_CELL_CONFIG_CNF 	= 4,
+  SS_CELL_RELEASE 	= 5,
+  SS_CELL_RELEASE_CNF 	= 6,
+  SS_VNG_CMD_REQ 	= 7,
+  SS_VNG_CMD_RESP 	= 8,
+  SS_INVALID_MSG 	= 0xFF
+} proxy_ss_msgs_e;
+
+typedef enum VngProxyCmd
+{
+    Vng_Invalid_Resp = 0,
+    Vng_Config_Cmd = 1,
+    Vng_Activate_Cmd = 2,
+    Vng_Deactivate_Cmd = 3,
+} VngProxyCmd_e;
+
+typedef enum CarrierBandwidthEUTRA_dl_Bandwidth_e {
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_n6 = 0,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_n15 = 1,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_n25 = 2,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_n50 = 3,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_n75 = 4,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_n100 = 5,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare10 = 6,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare9 = 7,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare8 = 8,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare7 = 9,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare6 = 10,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare5 = 11,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare4 = 12,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare3 = 13,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare2 = 14,
+        CarrierBandwidthEUTRA_dl_Bandwidth_e_spare1 = 15,
+} Dl_Bandwidth_e;
+
+	
+/*
+ * Proxy SS Header: To be used for comunication between Proxy and SS-eNB.
+ * 
+ * preamble: 0xFEEDC0DE for messages coming from SSeNB to Proxy
+ *           0xF00DC0DE for messages coming from Proxy to SSeNB
+ * msg_id  : To identify the message that is sent.
+ * length  : Length of the message in bytes. 
+ */
+typedef struct proxy_ss_header_s {
+  uint32_t preamble;
+  proxy_ss_msgs_e  msg_id;
+  uint8_t  cell_id;
+  uint16_t length;
+} proxy_ss_header_t, 
+ *proxy_ss_header_p;
+
+#define PROXY_CELL_CONFIG      ((1<<0))
+#define PROXY_CELLATTN_LIST    ((1<<1))
+#define PROXY_CELL_RELEASE     ((1<<2))
+#define PROXY_VNG_CMD          ((1<<3))
+
+typedef struct proxy_test_cfg_s {
+    uint8_t vt_enabled; /** Virtual time or real time */
+    uint8_t cli_rsrp_g; /** -dBm */
+    uint8_t cli_rsrq_g; /** -dBm */
+    uint16_t cli_periodicity_g; /** Subframes */
+} test_cfg_t, *test_cfg_p;
+
+typedef struct proxy_ss_cfg_s {
+  uint8_t softmodem_mode;
+  test_cfg_t cfg;
+  bool     active;
+  uint16_t sfn;
+  uint8_t  sf;
+  uint8_t  cfg_bitmap;
+  uint16_t cell_id;
+  uint16_t dl_earfcn;
+  uint16_t ul_earfcn;
+  uint32_t dl_freq;
+  uint32_t ul_freq;
+  int16_t  maxRefPower;
+  uint8_t  initialAttenuation;
+  uint8_t  currentAttnVal;
+  uint8_t  Noc_activated; /** 0 Not activated, 1 activated */
+  uint8_t  Noc_updated;
+  int32_t  NocLevel;
+  uint32_t Noc_Bandwidth;
+  uint8_t  rsrp_dbm;
+  uint8_t  rsrq_dbm;
+} proxy_ss_cfg_t,
+*proxy_ss_cfg_p;	
+
+/** Global pointer */
+extern proxy_ss_cfg_p ss_cfg_g;
+
+/** NOTE: Currently supporting only single cell */
+#define MAX_CELLS 1
+
+/** NOTE: Unused. There is only one cell at the moment. */
+typedef struct proxy_ss_cb_s {
+  uint8_t num_cells;
+  proxy_ss_cfg_p proxy_ss_cfg[MAX_CELLS];
+} proxy_ss_cb_t;
+
+int init_ss_config(void);
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/src/ss_proxy.c
+++ b/src/ss_proxy.c
@@ -1,0 +1,24 @@
+#include <stdint.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include "proxy_ss_interface.h"
+
+extern proxy_ss_cfg_p ss_cfg_g;
+
+int init_ss_config(void)
+{
+    ss_cfg_g = (proxy_ss_cfg_p) calloc (1, sizeof(proxy_ss_cfg_t));
+    if (NULL != ss_cfg_g) 
+    {
+        ss_cfg_g->active = true;
+        ss_cfg_g->cfg.cli_rsrp_g = DEFAULT_CELL_RSRP;
+        ss_cfg_g->cfg.cli_rsrq_g = DEFAULT_CELL_RSRQ;
+        ss_cfg_g->cfg.cli_periodicity_g = DEFAULT_CELL_SRCH_PERIOD;
+        return 0;
+    }
+    else
+    {
+        printf("System simulator init failed\n");
+	return -1;
+    }
+}


### PR DESCRIPTION
# Introduction

L2-Simulator setup needs the OAI eNB to run on nFAPI mode, where the L1 layer is bypassed and communication between OAI UE and eNB or nrUE and gNB happens over the nFAPI/FAPI P7 messages.

To accommodate the requirement of testing slower UE’s or UE’s in development stage which has processing time higher than slot/subframe duration, a feature called virtual time is introduced. With this feature UE can govern the slot/subframe boundary by sending an acknowledgement indicating its completion all its UL/DL processing for the current TTI.

At present this feature works on L2 nFAPI simulation mode only.

# Setup

Get the source code from OAI

```
$ git clone https://gitlab.eurecom.fr/oai/openairinterface5g.git
```

To checkout any specific tag under this repository

```
$ cd openairinterface5g
$ git checkout feature-virtual-time
```

This document refer paths to openairinterface5g and Multi-Ue-Proxy; the paths to these folders will be referred to as`<PATHTOOAI>` and `<PATHTOPROXY>` respectively.

*   `<PATHTOOAI> = /path/to/current/directory/openairinterface5g`
    
*   `<PATHTOPROXY> = /path/to/current/directory/Multi-Ue-Proxy` 
    

In future active stable branch will be ‘develop’ branch.

```
$ chmod 0777 oaienv
$ source oaienv
$ cd cmake_targets/
$ ./build_oai  --eNB --UE -c
```

```
$ cd ran_build/build
$ ../../../targets/bin/conf2uedata -c ../../../ci-scripts/conf_files/episci/episci_ue_test_sfr.conf -o .
$ ../../../targets/bin/usim -g -c ../../../ci-scripts/conf_files/episci/episci_ue_test_sfr.conf -o .
$ ../../../targets/bin/nvram -g -c ../../../ci-scripts/conf_files/episci/episci_ue_test_sfr.conf -o .
$ cp .u* ../../../cmake_targets
```

## OAI eNB

```
cd ../..
sudo -E ./ran_build/build/lte-softmodem -O ../ci-scripts/conf_files/firecell/proxy_rcc.band7.tm1.nfapi.conf \
 --log_config.global_log_options level,nocolor,time,thread_id | tee eNB.log 2>&1
```

In `proxy_rcc.band7.tm1.nfapi.conf` make sure that virtual time is enabled. Inside the conf file make sure to have the below entry

\# Asn1\_verbosity, choice in: none, info, annoying  
Asn1\_verbosity = "none";  
**virtual\_time = 1;**

## Multi-Ue-Proxy

```
$ cd <PATHTOPROXY>
```

```
$ make -j<number-of-jobs>
```

`number-of-jobs` can be based on the number of cores in your PC.

Use the `-v` option to **enable virtual time mode.**

```
sudo ./build/proxy 1 -v
```

# OAI UE

```
$ cd <PATHTOOAI>/cmake_targets
$ sudo ./ran_build/build/lte-uesoftmodem -O ../ci-scripts/conf_files/proxy_ue.nfapi.conf --L2-emul 5 --virtual-time 1 --nokrnmod 1 --num-ues 1 --node-number 2
```

An additional argument `--virtual-time` was introduced to enable and disable virtual time on OAI-UE.

OAI MR !1587 (Draft) has changes for OAI eNB & OAI UE