### PR TITLE
GitHub lte handover

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ The launch order is important, as follows.  Note, there are four different
 proxy modes: LTE, NSA, SA, and LTE HO.  Please refer to the table below to determine
 which executables to launch and the necessary flags for each command.  Steps
 1-5 below show how to launch NSA mode.  For example, in SA mode, replace the
-`--nsa` flag with `--nr` and only launch NRUE(s), a gNB and the proxy.
+`--nsa` flag with `--sa` and only launch NRUE(s), a gNB and the proxy.
 
 | Mode | Executables     |     Flags    |
 |------|-----------------|--------------|
@@ -125,8 +125,8 @@ which executables to launch and the necessary flags for each command.  Steps
 |      | lte-uesoftmodem |     --nsa    |
 |      | nr-softmodem    |     --nsa    |
 |      | nr-uesoftmodem  |     --nsa    |
-| SA   | nr-softmodem    |     --nr     |
-|      | nr-uesoftmodem  |     --nr     |
+| SA   | nr-softmodem    |     --sa     |
+|      | nr-uesoftmodem  |     --sa     |
 |LTE HO| lte-softmodem   |--lte_handover|
 |      | lte-uesoftmodem |--lte_handover|
 

--- a/README.md
+++ b/README.md
@@ -111,22 +111,24 @@ See `./proxy_testscript.py --help` for more information.
 
 ## Run without the proxy_testscript.py (Advanced) ##
 
-The launch order is important, as follows.  Note, there are three different
-proxy modes: LTE, NSA and SA.  Please refer to the table below to determine
+The launch order is important, as follows.  Note, there are four different
+proxy modes: LTE, NSA, SA, and LTE HO.  Please refer to the table below to determine
 which executables to launch and the necessary flags for each command.  Steps
 1-5 below show how to launch NSA mode.  For example, in SA mode, replace the
-`--nsa` flag with `--sa` and only launch NRUE(s), a gNB and the proxy.
+`--nsa` flag with `--nr` and only launch NRUE(s), a gNB and the proxy.
 
-| Mode | Executables     | Flags  |
-|------|-----------------|--------|
-| LTE  | lte-softmodem   | (none) |
-|      | lte-uesoftmodem | (none) |
-| NSA  | lte-softmodem   | --nsa  |
-|      | lte-uesoftmodem | --nsa  |
-|      | nr-softmodem    | --nsa  |
-|      | nr-uesoftmodem  | --nsa  |
-| SA   | nr-softmodem    | --sa   |
-|      | nr-uesoftmodem  | --sa   |
+| Mode | Executables     |     Flags    |
+|------|-----------------|--------------|
+| LTE  | lte-softmodem   |     (none)   |
+|      | lte-uesoftmodem |     (none)   |
+| NSA  | lte-softmodem   |     --nsa    |
+|      | lte-uesoftmodem |     --nsa    |
+|      | nr-softmodem    |     --nsa    |
+|      | nr-uesoftmodem  |     --nsa    |
+| SA   | nr-softmodem    |     --nr     |
+|      | nr-uesoftmodem  |     --nr     |
+|LTE HO| lte-softmodem   |--lte_handover|
+|      | lte-uesoftmodem |--lte_handover|
 
 ### 1. Open a terminal and launch eNB ###
 

--- a/README.md
+++ b/README.md
@@ -107,6 +107,12 @@ make
 ./proxy_testscript.py --num-ues 1 --mode=nr
 ```
 
+## Run LTE HO mode with the proxy_testscript.py (Recommended) ##
+
+```shell
+./proxy_testscript.py --num-ues 1 --mode=lte_handover
+```
+
 See `./proxy_testscript.py --help` for more information.
 
 ## Run without the proxy_testscript.py (Advanced) ##

--- a/open-nFAPI/pnf/public_inc/nfapi_pnf_interface.h
+++ b/open-nFAPI/pnf/public_inc/nfapi_pnf_interface.h
@@ -604,6 +604,7 @@ typedef struct nfapi_pnf_p7_config
 
 	/*! The PHY id*/
 	uint16_t phy_id;
+	int pnf_id;
 
 	// remote
 	/*! The VNF P7 UDP port */

--- a/open-nFAPI/pnf/src/pnf_p7.c
+++ b/open-nFAPI/pnf/src/pnf_p7.c
@@ -1656,7 +1656,7 @@ void pnf_handle_dl_config_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_
 			}
 
 			// saving dl_config_request in subframe buffer
-			transfer_downstream_nfapi_msg_to_proxy((void *)req);
+			transfer_downstream_nfapi_msg_to_proxy(pnf_p7->_public.pnf_id, (void *)req);
 			pnf_p7->subframe_buffer[buffer_index].sfn_sf = req->sfn_sf;
 			pnf_p7->subframe_buffer[buffer_index].dl_config_req = req;
 
@@ -1807,7 +1807,7 @@ void pnf_handle_ul_config_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_
 
 				deallocate_nfapi_ul_config_request(pnf_p7->subframe_buffer[buffer_index].ul_config_req, pnf_p7);
 			}
-			transfer_downstream_nfapi_msg_to_proxy((void *)req);
+			transfer_downstream_nfapi_msg_to_proxy(pnf_p7->_public.pnf_id, (void *)req);
 			pnf_p7->subframe_buffer[buffer_index].sfn_sf = req->sfn_sf;
 			pnf_p7->subframe_buffer[buffer_index].ul_config_req = req;
 			
@@ -1944,7 +1944,7 @@ void pnf_handle_hi_dci0_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_p7
 				deallocate_nfapi_hi_dci0_request(pnf_p7->subframe_buffer[buffer_index].hi_dci0_req, pnf_p7);
 			}
 
-			transfer_downstream_nfapi_msg_to_proxy((void *)req);
+			transfer_downstream_nfapi_msg_to_proxy(pnf_p7->_public.pnf_id, (void *)req);
 			pnf_p7->subframe_buffer[buffer_index].sfn_sf = req->sfn_sf;
 			pnf_p7->subframe_buffer[buffer_index].hi_dci0_req = req;
 
@@ -2047,7 +2047,7 @@ void pnf_handle_tx_request(void* pRecvMsg, int recvMsgLen, pnf_p7_t* pnf_p7)
 				deallocate_nfapi_tx_request(pnf_p7->subframe_buffer[buffer_index].tx_req, pnf_p7);
 			}
 
-			transfer_downstream_nfapi_msg_to_proxy((void *)req);
+			transfer_downstream_nfapi_msg_to_proxy(pnf_p7->_public.pnf_id, (void *)req);
 			pnf_p7->subframe_buffer[buffer_index].sfn_sf = req->sfn_sf;
 			pnf_p7->subframe_buffer[buffer_index].tx_req = req;
 

--- a/proxy_testscript.py
+++ b/proxy_testscript.py
@@ -263,6 +263,8 @@ class Scenario:
                           RUN_OAI=RUN_OAI)
             if OPTS.mode == 'nsa':
                 cmd += ' --nsa'
+            if OPTS.mode == 'lte_handover':
+                cmd += f' --num-enbs {len(self.enb_node_id)}'
             procs[num] = Popen(redirect_output(cmd, log_name), shell=True)
 
             # TODO: Sleep time needed so eNB and UEs don't start at the exact

--- a/proxy_testscript.py
+++ b/proxy_testscript.py
@@ -218,8 +218,6 @@ class Scenario:
     def launch_enb(self) -> Popen:
         procs = {}
         for num, hostname in self.enb_hostname.items():
-            #if len(self.enb_hostname) == 1:
-            #    num, hostname = None, 'eNB'
             log_name = '{}/{}.log'.format(OPTS.log_dir, hostname)
             LOGGER.info('Launch eNB%d: %s', num, log_name)
             cmd = 'NODE_NUMBER={NODE_ID} {RUN_OAI} enb' \

--- a/proxy_testscript.py
+++ b/proxy_testscript.py
@@ -602,6 +602,11 @@ def analyze_enb_logs(scenario: Scenario) -> bool:
                 found.add('rrc reconf complete to gnb')
                 continue
 
+            # 1612992.160273 00006d7a [RRC] I [eNB 0] Frame  0 : Logical Channel UL-DCCH, Received LTE_RRCConnectionReconfigurationComplete from UE rnti bfd1, reconfiguring DRB 1/LCID 3
+            if '[RRC] A Received HO LTE_RRCConnectionReconfigurationComplete' in line:
+                found.add('ho_msg3')
+                continue
+
         LOGGER.debug('found: %r', found)
 
         num_ues = len(scenario.ue_hostname)

--- a/proxy_testscript.py
+++ b/proxy_testscript.py
@@ -46,7 +46,7 @@ Don't run the scenario, only examine the logs in the --log-dir
 directory from a previous run of the scenario
 """)
 
-parser.add_argument('--mode', default='lte', choices='lte nr nsa'.split(),
+parser.add_argument('--mode', default='lte', choices='lte nr nsa lte_handover'.split(),
                     help="""
 The kind of simulation scenario to run
 (default: %(default)s)
@@ -152,8 +152,10 @@ class Scenario:
     """
 
     def __init__(self) -> None:
-        self.enb_hostname: Optional[str] = None
-        self.enb_node_id: Optional[int] = None
+        #self.enb_hostname: Optional[str] = None
+        #self.enb_node_id: Optional[int] = None
+        self.enb_hostname: Dict[int, str] = {}
+        self.enb_node_id: Dict[int, int] = {}
         self.ue_hostname: Dict[int, str] = {}
         self.ue_node_id: Dict[int, int] = {}
         self.gnb_hostname: Optional[str] = None
@@ -163,56 +165,78 @@ class Scenario:
 
         # Setup our data structures according to the command-line options
 
-        node_ids = NodeIdGenerator()
+        nodeB_ids = NodeIdGenerator()
+        ue_ids = NodeIdGenerator()
 
         if OPTS.mode == 'nsa':
             # Non-standalone mode: eNB, gNB, UEs and NRUEs
-            self.enb_hostname = 'eNB'
-            self.enb_node_id = node_ids()
+            eNB_id = 1
+            self.enb_hostname[eNB_id] = f'eNB{eNB_id}'
+            self.enb_node_id[eNB_id] = nodeB_ids()
+            self.gnb_hostname = 'gNB'
+            self.gnb_node_id = nodeB_ids()
             for i in range(OPTS.num_ues):
                 ue_num = i + 1
-                node_id = node_ids()
+                node_id = ue_ids()
                 self.ue_hostname[ue_num] = f'UE{ue_num}'
                 self.ue_node_id[ue_num] = node_id
                 self.nrue_hostname[ue_num] = f'NRUE{ue_num}'
                 self.nrue_node_id[ue_num] = node_id
-            self.gnb_hostname = 'gNB'
-            self.gnb_node_id = node_ids()
+
 
         if OPTS.mode == 'nr':
             # NR mode: gNB and NRUEs, no eNB, no UEs
             self.gnb_hostname = 'gNB'
-            self.gnb_node_id = node_ids()
+            self.gnb_node_id = nodeB_ids()
             for i in range(OPTS.num_ues):
                 ue_num = i + 1
                 self.nrue_hostname[ue_num] = f'NRUE{ue_num}'
-                self.nrue_node_id[ue_num] = node_ids()
+                self.nrue_node_id[ue_num] = ue_ids()
 
         if OPTS.mode == 'lte':
             # LTE mode: eNB and UEs, no gNB, no NRUEs
-            self.enb_hostname = 'eNB'
-            self.enb_node_id = node_ids()
+            eNB_id = 1
+            self.enb_hostname[eNB_id] = f'eNB{eNB_id}'
+            self.enb_node_id[eNB_id] = nodeB_ids()
+
             for i in range(OPTS.num_ues):
                 ue_num = i + 1
                 self.ue_hostname[ue_num] = f'UE{ue_num}'
-                self.ue_node_id[ue_num] = node_ids()
+                self.ue_node_id[ue_num] = ue_ids()
+
+        if OPTS.mode == 'lte_handover':
+            # LTE handover mode: 2 eNBs and UEs, no gNB, no NRUEs
+            for i in range(2):
+                eNB_id = i + 1
+                self.enb_hostname[eNB_id] = f'eNB{eNB_id}'
+                self.enb_node_id[eNB_id] = nodeB_ids()
+            for i in range(OPTS.num_ues):
+                ue_num = i + 1
+                self.ue_hostname[ue_num] = f'UE{ue_num}'
+                self.ue_node_id[ue_num] = ue_ids()
 
     def launch_enb(self) -> Popen:
-        log_name = '{}/eNB.log'.format(OPTS.log_dir)
-        LOGGER.info('Launch eNB: %s', log_name)
-        cmd = 'NODE_NUMBER=1 {RUN_OAI} enb' \
-              .format(RUN_OAI=RUN_OAI)
-        if OPTS.mode == 'nsa':
-            cmd += ' --nsa'
-        proc = Popen(redirect_output(cmd, log_name), shell=True)
+        procs = {}
+        for num, hostname in self.enb_hostname.items():
+            #if len(self.enb_hostname) == 1:
+            #    num, hostname = None, 'eNB'
+            log_name = '{}/{}.log'.format(OPTS.log_dir, hostname)
+            LOGGER.info('Launch eNB%d: %s', num, log_name)
+            cmd = 'NODE_NUMBER={NODE_ID} {RUN_OAI} enb' \
+                  .format(NODE_ID=self.enb_node_id[num],
+                          RUN_OAI=RUN_OAI)
+            if OPTS.mode == 'nsa':
+                cmd += ' --nsa'
+            procs[num] = Popen(redirect_output(cmd, log_name), shell=True)
 
-        # TODO: Sleep time needed so eNB and UEs don't start at the exact same
-        # time When nodes start at the same time, occasionally eNB will only
-        # recognize one UE I think this bug has been fixed -- the random
-        # number generator initializer issue
-        time.sleep(1)
+            # TODO: Sleep time needed so eNB and UEs don't start at the exact same
+            # time When nodes start at the same time, occasionally eNB will only
+            # recognize one UE I think this bug has been fixed -- the random
+            # number generator initializer issue
+            time.sleep(1)
 
-        return proc
+        return procs
+
 
     def launch_proxy(self) -> Popen:
         log_name = '{}/nfapi.log'.format(OPTS.log_dir)
@@ -329,12 +353,13 @@ class Scenario:
 
         if enb_proc:
             # See if the eNB crashed
-            status = enb_proc.poll()
-            if status is None:
-                LOGGER.info('eNB process is still running, which is good')
-            else:
-                passed = False
-                LOGGER.critical('eNB process ended early: %r', status)
+            for enb_number in self.enb_hostname:
+                status = enb_proc[enb_number].poll()
+                if status is None:
+                    LOGGER.info('eNB%d process is still running, which is good', enb_number)
+                else:
+                    passed = False
+                    LOGGER.critical('eNB%d process ended early: %r', enb_number, status)
 
         if proxy_proc:
             # See if the proxy crashed
@@ -395,7 +420,8 @@ class Scenario:
         # Wait for the processes to end
         proxy_proc.wait()
         if enb_proc:
-            enb_proc.wait()
+            for proc in enb_proc.values():
+                proc.wait()
         if gnb_proc:
             gnb_proc.wait()
         for proc in ue_proc.values():
@@ -416,7 +442,8 @@ class Scenario:
         # Compress eNB.log, UE*.log, gNB.log and NRUE*.log
         jobs = CompressJobs()
         if enb_proc:
-            jobs.compress('{}/eNB.log'.format(OPTS.log_dir), remove_original=True)
+            for enb_hostname in self.enb_hostname.values():
+                jobs.compress('{}/{}.log'.format(OPTS.log_dir, enb_hostname), remove_original=True)
         if ue_proc:
             for ue_hostname in self.ue_hostname.values():
                 jobs.compress('{}/{}.log'.format(OPTS.log_dir, ue_hostname), remove_original=True)
@@ -513,81 +540,93 @@ def analyze_enb_logs(scenario: Scenario) -> bool:
         LOGGER.info('No eNB in this scenario')
         return True
 
-    found = set()
-    for line in get_analysis_messages('{}/eNB.log.bz2'.format(OPTS.log_dir)):
-        # 94772.731183 00000057 [MAC] A Configuring MIB for instance 0, CCid 0 : (band
-        # 7,N_RB_DL 50,Nid_cell 0,p 1,DL freq 2685000000,phich_config.resource 0,
-        # phich_config.duration 0)
-        if '[MAC] A Configuring MIB ' in line:
-            found.add('configured')
-            continue
+    num_failed = 0
+    for enb_number, enb_hostname in scenario.enb_hostname.items():
+        found = set()
+        for line in get_analysis_messages('{}/{}.log.bz2'.format(OPTS.log_dir, enb_hostname)):
+            # 94772.731183 00000057 [MAC] A Configuring MIB for instance 0, CCid 0 : (band
+            # 7,N_RB_DL 50,Nid_cell 0,p 1,DL freq 2685000000,phich_config.resource 0,
+            # phich_config.duration 0)
+            if '[MAC] A Configuring MIB ' in line:
+                found.add('configured')
+                continue
 
-        # 94777.679273 00000057 [MAC] A [eNB 0][RAPROC] CC_id 0 Frame 74, subframeP 3:
-        # Generating Msg4 with RRC Piggyback (RNTI a67)
-        if 'Generating Msg4 with RRC Piggyback' in line:
-            found.add('msg4')
-            continue
+            # 94777.679273 00000057 [MAC] A [eNB 0][RAPROC] CC_id 0 Frame 74, subframeP 3:
+            # Generating Msg4 with RRC Piggyback (RNTI a67)
+            if 'Generating Msg4 with RRC Piggyback' in line:
+                found.add('msg4')
+                continue
 
-        # 94777.695277 00000057 [RRC] A [FRAME 00000][eNB][MOD 00][RNTI a67] [RAPROC]
-        # Logical Channel UL-DCCH, processing LTE_RRCConnectionSetupComplete
-        # from UE (SRB1 Active)
-        if 'processing LTE_RRCConnectionSetupComplete from UE ' in line:
-            found.add('setup')
-            continue
+            # 94777.695277 00000057 [RRC] A [FRAME 00000][eNB][MOD 00][RNTI a67] [RAPROC]
+            # Logical Channel UL-DCCH, processing LTE_RRCConnectionSetupComplete
+            # from UE (SRB1 Active)
+            if 'processing LTE_RRCConnectionSetupComplete from UE ' in line:
+                found.add('setup')
+                continue
 
-        # 94776.725081 00000057 [RRC] A got UE capabilities for UE 6860
-        match = re.search(r'\[RRC\] A (got UE capabilities for UE \w+)$', line)
-        if match:
-            found.add(match.group(1))
-            continue
+            # 94776.725081 00000057 [RRC] A got UE capabilities for UE 6860
+            match = re.search(r'\[RRC\] A (got UE capabilities for UE \w+)$', line)
+            if match:
+                found.add(match.group(1))
+                continue
 
-        # 2075586.647598 00006b4a [RRC] A Generating
-        # RRCCConnectionReconfigurationRequest (NRUE Measurement Report
-        # Request).
-        if '[RRC] A Generating RRCCConnectionReconfigurationRequest (NRUE Measurement Report Request)' in line:
-            found.add('gen nrue meas report req')
-            continue
+            # 2075586.647598 00006b4a [RRC] A Generating
+            # RRCCConnectionReconfigurationRequest (NRUE Measurement Report
+            # Request).
+            if '[RRC] A Generating RRCCConnectionReconfigurationRequest (NRUE Measurement Report Request)' in line:
+                found.add('gen nrue meas report req')
+                continue
 
-        # 2075586.671139 00006b4a [RRC] A [FRAME 00000][eNB][MOD 00][RNTI
-        # e9fb] Logical Channel DL-DCCH, Generate NR UECapabilityEnquiry
-        # (bytes 11)
-        if ' Logical Channel DL-DCCH, Generate NR UECapabilityEnquiry' in line:
-            found.add('dl-dcch gen nrue cap enq')
-            continue
+            # 2075586.671139 00006b4a [RRC] A [FRAME 00000][eNB][MOD 00][RNTI
+            # e9fb] Logical Channel DL-DCCH, Generate NR UECapabilityEnquiry
+            # (bytes 11)
+            if ' Logical Channel DL-DCCH, Generate NR UECapabilityEnquiry' in line:
+                found.add('dl-dcch gen nrue cap enq')
+                continue
 
-        # 2075586.677066 00006b4a [RRC] A got nrUE capabilities for UE e9fb
-        match = re.search(r'\[RRC\] (got nrUE capabilities for UE \w+)$', line)
-        if match:
-            found.add(match.group(1))
-            continue
+            # 2075586.677066 00006b4a [RRC] A got nrUE capabilities for UE e9fb
+            match = re.search(r'\[RRC\] (got nrUE capabilities for UE \w+)$', line)
+            if match:
+                found.add(match.group(1))
+                continue
 
-        # 2075586.756959 00006b4a [RRC] A [eNB 0] frame 0 subframe 0: UE rnti
-        # e9fb switching to NSA mode
-        match = re.search(r': (UE rnti \w+ switching to NSA mode)', line)
-        if match:
-            found.add(match.group(1))
-            continue
+            # 2075586.756959 00006b4a [RRC] A [eNB 0] frame 0 subframe 0: UE rnti
+            # e9fb switching to NSA mode
+            match = re.search(r': (UE rnti \w+ switching to NSA mode)', line)
+            if match:
+                found.add(match.group(1))
+                continue
 
-        # 2075586.911204 00006b4a [RRC] A Sent rrcReconfigurationComplete to gNB
-        if '[RRC] A Sent rrcReconfigurationComplete to gNB' in line:
-            found.add('rrc reconf complete to gnb')
-            continue
+            # 2075586.911204 00006b4a [RRC] A Sent rrcReconfigurationComplete to gNB
+            if '[RRC] A Sent rrcReconfigurationComplete to gNB' in line:
+                found.add('rrc reconf complete to gnb')
+                continue
 
-    LOGGER.debug('found: %r', found)
+        LOGGER.debug('found: %r', found)
 
-    num_ues = len(scenario.ue_hostname)
-    LOGGER.debug('num UEs: %d', num_ues)
+        num_ues = len(scenario.ue_hostname)
+        LOGGER.debug('num UEs: %d', num_ues)
 
-    if OPTS.mode == 'lte' and len(found) == 3 + num_ues:
-        LOGGER.info('eNB passed')
-        return True
+        if OPTS.mode == 'lte' and len(found) == 3 + num_ues:
+            LOGGER.info('eNB%d passed', enb_number)
 
-    if OPTS.mode == 'nsa' and len(found) == 6 + 2 * num_ues:
-        LOGGER.info('eNB passed')
-        return True
+        elif OPTS.mode == 'lte_handover' and len(found) == 3 + num_ues:
+            LOGGER.info('eNB%d passed', enb_number)
 
-    LOGGER.error('eNB failed -- found %d %r', len(found), found)
-    return False
+        elif OPTS.mode == 'nsa' and len(found) == 6 + 2 * num_ues:
+            LOGGER.info('eNB%d passed', enb_number)
+
+        else:
+            num_failed += 1
+            LOGGER.error('eNB%d failed -- found %d %r', enb_number, len(found), found)
+
+    if num_failed != 0:
+        LOGGER.critical('%d of %d eNBs failed', num_failed, len(scenario.enb_hostname))
+        return False
+
+    LOGGER.info('All eNBs passed')
+    return True
+
 
 def analyze_ue_logs(scenario: Scenario) -> bool:
     if not scenario.ue_hostname:
@@ -661,6 +700,8 @@ def analyze_ue_logs(scenario: Scenario) -> bool:
                 continue
 
         if OPTS.mode == 'lte' and len(found) == 4:
+            LOGGER.info('UE%d passed', ue_number)
+        elif OPTS.mode == 'lte_handover' and len(found) == 4:
             LOGGER.info('UE%d passed', ue_number)
         elif OPTS.mode == 'nsa' and len(found) == 10:
             LOGGER.info('UE%d passed', ue_number)
@@ -937,7 +978,9 @@ def main() -> int:
     scenario = Scenario()
 
     if scenario.enb_hostname:
-        LOGGER.info('eNB node number %d', scenario.enb_node_id)
+        LOGGER.info('eNB node number%s %s',
+                    '' if len(scenario.enb_node_id) == 1 else 's',
+                    ' '.join(map(str, scenario.enb_node_id.values())))
 
     if scenario.gnb_hostname:
         LOGGER.info('gNB node number %d', scenario.gnb_node_id)
@@ -978,7 +1021,9 @@ def main() -> int:
 
     # Summarize any interesting entries in the logs
     summarize_logs('{}/nfapi-proxy.log.bz2'.format(OPTS.log_dir))
-    summarize_logs('{}/eNB.log.bz2'.format(OPTS.log_dir))
+    #summarize_logs('{}/eNB.log.bz2'.format(OPTS.log_dir))
+    for _enb_number, enb_hostname in scenario.enb_hostname.items():
+        summarize_logs('{}/{}.log.bz2'.format(OPTS.log_dir, enb_hostname))
     for _ue_number, ue_hostname in scenario.ue_hostname.items():
         summarize_logs('{}/{}.log.bz2'.format(OPTS.log_dir, ue_hostname))
     summarize_logs('{}/gNB.log.bz2'.format(OPTS.log_dir))

--- a/run-oai
+++ b/run-oai
@@ -37,12 +37,18 @@ export MALLOC_CHECK_=3
 case "$node_type" in
     (enb)
         echo "Node $NODE_NUMBER: eNB"
+        if [ $NODE_NUMBER = "1" ]; then
+            conf=proxy_rcc.band7.tm1.nfapi.conf # Target eNB
+        else
+            conf=proxy_rcc.band7.tm1.nfapi_$NODE_NUMBER.conf # Source eNB
+        fi
         cmd=(
             # Keep the eNB on processor 1 (the second processor) by default
             taskset --cpu-list 1
             ./ran_build/build/lte-softmodem
-            -O ../ci-scripts/conf_files/episci/proxy_rcc.band7.tm1.nfapi.conf
+            -O "../ci-scripts/conf_files/episci/$conf"
             --noS1
+            --node-number "$NODE_NUMBER"
             --emulate-l1
             --log_config.global_log_options level,nocolor,time,thread_id
         )

--- a/run-oai
+++ b/run-oai
@@ -56,7 +56,7 @@ case "$node_type" in
         if [ $NODE_NUMBER = "1" ]; then
             conf=proxy_rcc.band7.tm1.nfapi.conf # Source eNB
         else
-            conf=proxy_rcc.band7.tm1.nfapi_$NODE_NUMBER.conf # Target eNB
+            conf=proxy_rcc.band7.tm1.nfapi_target.conf # Target eNB
         fi
         cmd=(
             # Keep the eNB on processor 1 (the second processor) by default

--- a/run-oai
+++ b/run-oai
@@ -2,9 +2,25 @@
 
 use_strace=false
 use_valgrind=false
+mimo_mode=false
+nsa_mode=false
+num_enbs=1
 
 while (( $# > 0 )); do
     case "$1" in
+      (--mimo)
+          mimo_mode=true
+          shift
+          ;;
+      (--nsa)
+          nsa_mode=true
+          shift
+          ;;
+      (--num-enbs)
+          shift
+          num_enbs=$1
+          shift
+          ;;
       (--strace)
           use_strace=true
           shift
@@ -38,9 +54,9 @@ case "$node_type" in
     (enb)
         echo "Node $NODE_NUMBER: eNB"
         if [ $NODE_NUMBER = "1" ]; then
-            conf=proxy_rcc.band7.tm1.nfapi.conf # Target eNB
+            conf=proxy_rcc.band7.tm1.nfapi.conf # Source eNB
         else
-            conf=proxy_rcc.band7.tm1.nfapi_$NODE_NUMBER.conf # Source eNB
+            conf=proxy_rcc.band7.tm1.nfapi_$NODE_NUMBER.conf # Target eNB
         fi
         cmd=(
             # Keep the eNB on processor 1 (the second processor) by default
@@ -57,7 +73,11 @@ case "$node_type" in
     (gnb)
         echo "Node $NODE_NUMBER: gNB"
         if [[ " $* " = *" --sa "* ]]; then
-            conf=proxy_gnb.band78.sa.fr1.106PRB.usrpn310.conf
+            if $mimo_mode; then
+                conf=proxy_gnb.band78.sa.fr1.106PRB.usrpn310_mimo.conf
+            else
+                conf=proxy_gnb.band78.sa.fr1.106PRB.usrpn310.conf
+            fi
         else
             conf=proxy_rcc.band78.tm1.106PRB.nfapi.conf
         fi
@@ -148,6 +168,7 @@ fi
 # In case we're running with gprof profiling enabled.
 # https://stackoverflow.com/questions/464116/any-way-to-specify-the-location-of-profile-data
 export GMON_OUT_PREFIX=gmon-$NODE_NUMBER.out
+export LD_LIBRARY_PATH=$PWD/ran_build/build:$LD_LIBRARY_PATH
 
 # Enable core dumps.  You may want to set core_pattern:
 #  sudo sh -c 'echo /tmp/coredump-%P > /proc/sys/kernel/core_pattern'

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -12,7 +12,10 @@ Multi_UE_Proxy::Multi_UE_Proxy(int num_of_ues, std::vector<std::string> enb_ips,
 {
     assert(instance == NULL);
     instance = this;
-    eNB_id = 0;
+    for (int ue_idx = 0; ue_idx < num_of_ues; ue_idx++)
+    {
+        eNB_id[ue_idx] = 0;
+    }
 
     num_ues = num_of_ues ;
     int num_of_enbs = enb_ips.size();
@@ -174,11 +177,11 @@ void Multi_UE_Proxy::receive_message_from_ue(int ue_idx)
                 return ;
             }
             uint16_t sfn_sf = nfapi_get_sfnsf(buffer, buflen);
-            eNB_id = header.phy_id;
+            eNB_id[ue_idx] = header.phy_id;
             NFAPI_TRACE(NFAPI_TRACE_INFO , "(Proxy) Proxy has received %d uplink message from OAI UE for eNB%u at socket. Frame: %d, Subframe: %d",
-                    header.message_id, eNB_id, NFAPI_SFNSF2SFN(sfn_sf), NFAPI_SFNSF2SF(sfn_sf));
+                    header.message_id, eNB_id[ue_idx], NFAPI_SFNSF2SFN(sfn_sf), NFAPI_SFNSF2SF(sfn_sf));
         }
-        oai_subframe_handle_msg_from_ue(eNB_id, buffer, buflen, ue_idx + 2);
+        oai_subframe_handle_msg_from_ue(eNB_id[ue_idx], buffer, buflen, ue_idx + 2);
     }
 }
 
@@ -190,9 +193,6 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(int id, void *msg_org)
 
     if (msg_org == NULL) {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "P7 Pack supplied pointers are null\n");
-        return;
-    }
-    if (id != eNB_id) {
         return;
     }
     pHeader->phy_id = id;
@@ -222,6 +222,9 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(int id, void *msg_org)
 
     for(int ue_idx = 0; ue_idx < num_ues; ue_idx++)
     {
+        if (id != eNB_id[ue_idx]) {
+            continue;
+        }
         address_tx_.sin_port = htons(3212 + ue_idx * port_delta);
         uint16_t id_=1;
         switch (msg.header.message_id)

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -174,8 +174,9 @@ void Multi_UE_Proxy::receive_message_from_ue(int ue_idx)
                 return ;
             }
             uint16_t sfn_sf = nfapi_get_sfnsf(buffer, buflen);
-            NFAPI_TRACE(NFAPI_TRACE_INFO , "(Proxy) Proxy has received %d uplink message from OAI UE at socket. Frame: %d, Subframe: %d",
-                    header.message_id, NFAPI_SFNSF2SFN(sfn_sf), NFAPI_SFNSF2SF(sfn_sf));
+            taget_eNB_id = header.phy_id;
+            NFAPI_TRACE(NFAPI_TRACE_INFO , "(Proxy) Proxy has received %d uplink message from OAI UE for eNB%u at socket. Frame: %d, Subframe: %d",
+                    header.message_id, taget_eNB_id, NFAPI_SFNSF2SFN(sfn_sf), NFAPI_SFNSF2SF(sfn_sf));
         }
         oai_subframe_handle_msg_from_ue(taget_eNB_id, buffer, buflen, ue_idx + 2);
     }
@@ -277,13 +278,13 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(int id, void *msg_org)
     }
 }
 
-void Multi_UE_Proxy::pack_and_send_downlink_sfn_sf_msg(int id, uint16_t sfn_sf)
+void Multi_UE_Proxy::pack_and_send_downlink_sfn_sf_msg(uint16_t id, uint16_t sfn_sf)
 {
     lock_guard_t lock(mutex);
 
     sfn_sf_info_t sfn_sf_info;
+    sfn_sf_info.phy_id = id;
     sfn_sf_info.sfn_sf = sfn_sf;
-    sfn_sf_info.cell_id = id;
 
     for(int ue_idx = 0; ue_idx < num_ues; ue_idx++)
     {
@@ -298,11 +299,11 @@ void Multi_UE_Proxy::pack_and_send_downlink_sfn_sf_msg(int id, uint16_t sfn_sf)
     }
 }
 
-void transfer_downstream_nfapi_msg_to_proxy(int id, void *msg)
+void transfer_downstream_nfapi_msg_to_proxy(uint16_t id, void *msg)
 {
     instance->oai_enb_downlink_nfapi_task(id, msg);
 }
-void transfer_downstream_sfn_sf_to_proxy(int id, uint16_t sfn_sf)
+void transfer_downstream_sfn_sf_to_proxy(uint16_t id, uint16_t sfn_sf)
 {
     instance->pack_and_send_downlink_sfn_sf_msg(id, sfn_sf);
 }

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -32,9 +32,6 @@ void Multi_UE_Proxy::start(softmodem_mode_t softmodem_mode)
 
     configure_nfapi_pnf(id, vnf_ipaddr.c_str(), vnf_p5port, pnf_ipaddr.c_str(), pnf_p7port, vnf_p7port);
 
-    if (id > 0)
-        return;
-
     if (pthread_create(&thread, NULL, &oai_subframe_task, (void *)&args) != 0)
     {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "pthread_create failed for calling oai_subframe_task");

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -154,7 +154,7 @@ void Multi_UE_Proxy::receive_message_from_ue(int ue_idx)
     }
 }
 
-void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(void *msg_org)
+void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(int id, void *msg_org)
 {
     lock_guard_t lock(mutex);
 
@@ -183,7 +183,7 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(void *msg_org)
 
     for(int ue_idx = 0; ue_idx < num_ues; ue_idx++)
     {
-        address_tx_.sin_port = htons(3212 + ue_idx * port_delta);
+        address_tx_.sin_port = htons(3212 + id * enb_port_delta + ue_idx * port_delta);
         uint16_t id_=1;
         switch (msg.header.message_id)
         {
@@ -250,13 +250,13 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(void *msg_org)
     }
 }
 
-void Multi_UE_Proxy::pack_and_send_downlink_sfn_sf_msg(uint16_t sfn_sf)
+void Multi_UE_Proxy::pack_and_send_downlink_sfn_sf_msg(int id, uint16_t sfn_sf)
 {
     lock_guard_t lock(mutex);
 
     for(int ue_idx = 0; ue_idx < num_ues; ue_idx++)
     {
-        address_tx_.sin_port = htons(3212 + ue_idx * port_delta);
+        address_tx_.sin_port = htons(3212 + id * enb_port_delta + ue_idx * port_delta);
         assert(ue_tx_socket[ue_idx] > 2);
         if (sendto(ue_tx_socket[ue_idx], &sfn_sf, sizeof(sfn_sf), 0, (const struct sockaddr *) &address_tx_, sizeof(address_tx_)) < 0)
         {
@@ -269,9 +269,9 @@ void Multi_UE_Proxy::pack_and_send_downlink_sfn_sf_msg(uint16_t sfn_sf)
 
 void transfer_downstream_nfapi_msg_to_proxy(int id, void *msg)
 {
-    instances[id]->oai_enb_downlink_nfapi_task(msg);
+    instances[id]->oai_enb_downlink_nfapi_task(id, msg);
 }
 void transfer_downstream_sfn_sf_to_proxy(int id, uint16_t sfn_sf)
 {
-    instances[id]->pack_and_send_downlink_sfn_sf_msg(sfn_sf);
+    instances[id]->pack_and_send_downlink_sfn_sf_msg(id, sfn_sf);
 }

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -12,7 +12,7 @@ Multi_UE_Proxy::Multi_UE_Proxy(int num_of_ues, std::vector<std::string> enb_ips,
 {
     assert(instance == NULL);
     instance = this;
-    taget_eNB_id = 0;
+    eNB_id = 0;
 
     num_ues = num_of_ues ;
     int num_of_enbs = enb_ips.size();
@@ -174,11 +174,11 @@ void Multi_UE_Proxy::receive_message_from_ue(int ue_idx)
                 return ;
             }
             uint16_t sfn_sf = nfapi_get_sfnsf(buffer, buflen);
-            taget_eNB_id = header.phy_id;
+            eNB_id = header.phy_id;
             NFAPI_TRACE(NFAPI_TRACE_INFO , "(Proxy) Proxy has received %d uplink message from OAI UE for eNB%u at socket. Frame: %d, Subframe: %d",
-                    header.message_id, taget_eNB_id, NFAPI_SFNSF2SFN(sfn_sf), NFAPI_SFNSF2SF(sfn_sf));
+                    header.message_id, eNB_id, NFAPI_SFNSF2SFN(sfn_sf), NFAPI_SFNSF2SF(sfn_sf));
         }
-        oai_subframe_handle_msg_from_ue(taget_eNB_id, buffer, buflen, ue_idx + 2);
+        oai_subframe_handle_msg_from_ue(eNB_id, buffer, buflen, ue_idx + 2);
     }
 }
 
@@ -190,6 +190,9 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(int id, void *msg_org)
 
     if (msg_org == NULL) {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "P7 Pack supplied pointers are null\n");
+        return;
+    }
+    if (id != eNB_id) {
         return;
     }
     pHeader->phy_id = id;

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -186,6 +186,14 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(int id, void *msg_org)
 {
     lock_guard_t lock(mutex);
 
+    nfapi_p7_message_header_t *pHeader = (nfapi_p7_message_header_t *)msg_org;
+
+    if (msg_org == NULL) {
+        NFAPI_TRACE(NFAPI_TRACE_ERROR, "P7 Pack supplied pointers are null\n");
+        return;
+    }
+    pHeader->phy_id = id;
+
     char buffer[NFAPI_MAX_PACKED_MESSAGE_SIZE];
     int encoded_size = nfapi_p7_message_pack(msg_org, buffer, sizeof(buffer), nullptr);
     if (encoded_size <= 0)

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -58,7 +58,7 @@ public:
     void start(softmodem_mode_t softmodem_mode);
     std::vector<Multi_UE_PNF> lte_pnfs;
 private:
-    uint16_t eNB_id; // To identify the destination in uplink
+    uint16_t eNB_id[100]; // To identify the destination in uplink
     std::string oai_ue_ipaddr;
     std::string vnf_ipaddr;
     std::string pnf_ipaddr;

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -50,7 +50,7 @@ public:
     int init_oai_socket(const char *addr, int tx_port, int rx_port, int ue_idx);
     void oai_enb_downlink_nfapi_task(int id, void *msg);
     void testcode_tx_packet_to_UE( int ue_tx_socket_);
-    void pack_and_send_downlink_sfn_sf_msg(int id, uint16_t sfn_sf);
+    void pack_and_send_downlink_sfn_sf_msg(uint16_t id, uint16_t sfn_sf);
     void receive_message_from_ue(int ue_id);
     void send_ue_to_enb_msg(void *buffer, size_t buflen);
     void send_received_msg_to_proxy_queue(void *buffer, size_t buflen);
@@ -58,7 +58,7 @@ public:
     void start(softmodem_mode_t softmodem_mode);
     std::vector<Multi_UE_PNF> lte_pnfs;
 private:
-    int taget_eNB_id; // To identify the destination in uplink
+    uint16_t taget_eNB_id; // To identify the destination in uplink
     std::string oai_ue_ipaddr;
     std::string vnf_ipaddr;
     std::string pnf_ipaddr;
@@ -75,8 +75,8 @@ private:
 
     typedef struct sfn_sf_info_s
     {
+        uint16_t phy_id;
         uint16_t sfn_sf;
-        uint16_t cell_id;
     } sfn_sf_info_t;
 
     std::recursive_mutex mutex;

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -30,9 +30,9 @@ public:
     ~Multi_UE_Proxy() = default;
     void configure(std::string enb_ip, std::string proxy_ip, std::string ue_ip);
     int init_oai_socket(const char *addr, int tx_port, int rx_port, int ue_idx);
-    void oai_enb_downlink_nfapi_task(void *msg);
+    void oai_enb_downlink_nfapi_task(int id, void *msg);
     void testcode_tx_packet_to_UE( int ue_tx_socket_);
-    void pack_and_send_downlink_sfn_sf_msg(uint16_t sfn_sf);
+    void pack_and_send_downlink_sfn_sf_msg(int id, uint16_t sfn_sf);
     void receive_message_from_ue(int ue_id);
     void send_ue_to_enb_msg(void *buffer, size_t buflen);
     void send_received_msg_to_proxy_queue(void *buffer, size_t buflen);

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -23,12 +23,30 @@
 #include <thread>
 #include "proxy.h"
 
+class Multi_UE_PNF
+{
+public:
+    Multi_UE_PNF(int id, int num_of_ues, std::string enb_ip, std::string proxy_ip);
+    ~Multi_UE_PNF() = default;
+    void configure(std::string enb_ip, std::string proxy_ip);
+    void start(softmodem_mode_t softmodem_mode);
+private:
+    std::string oai_ue_ipaddr;
+    std::string vnf_ipaddr;
+    std::string pnf_ipaddr;
+    int vnf_p5port = -1;
+    int vnf_p7port = -1;
+    int pnf_p7port = -1;
+    int id;
+    const int enb_port_delta = 200;
+};
+
 class Multi_UE_Proxy
 {
 public:
-    Multi_UE_Proxy(int id, int num_of_ues, std::string enb_ip, std::string proxy_ip, std::string ue_ip);
+    Multi_UE_Proxy(int num_of_ues, std::vector<std::string> enb_ips, std::string proxy_ip, std::string ue_ip);
     ~Multi_UE_Proxy() = default;
-    void configure(std::string enb_ip, std::string proxy_ip, std::string ue_ip);
+    void configure(std::string ue_ip);
     int init_oai_socket(const char *addr, int tx_port, int rx_port, int ue_idx);
     void oai_enb_downlink_nfapi_task(int id, void *msg);
     void testcode_tx_packet_to_UE( int ue_tx_socket_);
@@ -38,7 +56,9 @@ public:
     void send_received_msg_to_proxy_queue(void *buffer, size_t buflen);
     void send_uplink_oai_msg_to_proxy_queue(void *buffer, size_t buflen);
     void start(softmodem_mode_t softmodem_mode);
+    std::vector<Multi_UE_PNF> lte_pnfs;
 private:
+    int taget_eNB_id; // To identify the destination in uplink
     std::string oai_ue_ipaddr;
     std::string vnf_ipaddr;
     std::string pnf_ipaddr;
@@ -46,18 +66,22 @@ private:
     int vnf_p7port = -1;
     int pnf_p7port = -1;
 
-    std::uint16_t u16SequenceNumber_ = 0;
     struct sockaddr_in address_tx_;
     struct sockaddr_in address_rx_;
     int ue_tx_socket_ = -1;
     int ue_rx_socket_ = -1;
     int ue_rx_socket[100];
     int ue_tx_socket[100];
-    int id ;
+
+    typedef struct sfn_sf_info_s
+    {
+        uint16_t sfn_sf;
+        uint16_t cell_id;
+    } sfn_sf_info_t;
+
     std::recursive_mutex mutex;
     using lock_guard_t = std::lock_guard<std::recursive_mutex>;
     std::vector<std::thread> threads;
     bool stop_thread = false;
     const int port_delta = 2;
-    const int enb_port_delta = 200;
 };

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -59,5 +59,5 @@ private:
     std::vector<std::thread> threads;
     bool stop_thread = false;
     const int port_delta = 2;
-    const int enb_port_delta = 600;
+    const int enb_port_delta = 300;
 };

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -59,5 +59,5 @@ private:
     std::vector<std::thread> threads;
     bool stop_thread = false;
     const int port_delta = 2;
-    const int enb_port_delta = 300;
+    const int enb_port_delta = 200;
 };

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -58,7 +58,7 @@ public:
     void start(softmodem_mode_t softmodem_mode);
     std::vector<Multi_UE_PNF> lte_pnfs;
 private:
-    uint16_t taget_eNB_id; // To identify the destination in uplink
+    uint16_t eNB_id; // To identify the destination in uplink
     std::string oai_ue_ipaddr;
     std::string vnf_ipaddr;
     std::string pnf_ipaddr;

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -26,7 +26,7 @@
 class Multi_UE_Proxy
 {
 public:
-    Multi_UE_Proxy(int num_of_ues, std::string enb_ip, std::string proxy_ip, std::string ue_ip);
+    Multi_UE_Proxy(int id, int num_of_ues, std::string enb_ip, std::string proxy_ip, std::string ue_ip);
     ~Multi_UE_Proxy() = default;
     void configure(std::string enb_ip, std::string proxy_ip, std::string ue_ip);
     int init_oai_socket(const char *addr, int tx_port, int rx_port, int ue_idx);
@@ -53,10 +53,11 @@ private:
     int ue_rx_socket_ = -1;
     int ue_rx_socket[100];
     int ue_tx_socket[100];
-    std::uint16_t id ;
+    int id ;
     std::recursive_mutex mutex;
     using lock_guard_t = std::lock_guard<std::recursive_mutex>;
     std::vector<std::thread> threads;
     bool stop_thread = false;
-    int port_delta = 2;
+    const int port_delta = 2;
+    const int enb_port_delta = 600;
 };

--- a/src/nfapi_pnf.c
+++ b/src/nfapi_pnf.c
@@ -4488,8 +4488,8 @@ int oai_nfapi_rach_ind(int id, nfapi_rach_indication_t *rach_ind)
 
     rach_ind->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
 
-    NFAPI_TRACE(NFAPI_TRACE_INFO, "Sent the rach to eNB sf: %u sfn : %u num of preambles: %u",
-               rach_ind->sfn_sf & 0xF, rach_ind->sfn_sf >> 4, rach_ind->rach_indication_body.number_of_preambles);
+    NFAPI_TRACE(NFAPI_TRACE_INFO, "Sent the rach to eNB%d sf: %u sfn : %u num of preambles: %u",
+               id, rach_ind->sfn_sf & 0xF, rach_ind->sfn_sf >> 4, rach_ind->rach_indication_body.number_of_preambles);
 
     return nfapi_pnf_p7_rach_ind(p7_config_g[id], rach_ind);
 }

--- a/src/nfapi_pnf.c
+++ b/src/nfapi_pnf.c
@@ -4399,7 +4399,7 @@ void *oai_slot_task(void *context)
     }
 }
 
-void oai_subframe_handle_msg_from_ue(int enb_id, const void *msg, size_t len, uint16_t nem_id)
+void oai_subframe_handle_msg_from_ue(uint16_t enb_id, const void *msg, size_t len, uint16_t nem_id)
 {
     if (len == 4) // Dummy packet ignore
     {

--- a/src/nfapi_pnf.c
+++ b/src/nfapi_pnf.c
@@ -63,16 +63,16 @@ nfapi_tx_request_pdu_t *tx_request_pdu[1023][10][10]; // [frame][subframe][max_n
 nfapi_nr_pdu_t *tx_data_request[1023][20][10]; //[frame][slot][max_num_pdus]
 nfapi_ue_release_request_body_t release_rntis;
 nfapi_pnf_param_response_t g_pnf_param_resp;
-nfapi_pnf_p7_config_t *p7_config_g = NULL;
+nfapi_pnf_p7_config_t *p7_config_g[MAX_ENB];
 nfapi_pnf_p7_config_t *p7_nr_config_g = NULL;
 
 uint8_t tx_pdus[32][8][4096];
 uint8_t nr_tx_pdus[32][16][4096];
 uint16_t phy_antenna_capability_values[] = { 1, 2, 4, 8, 16 };
 
-static pnf_info pnf;
+static pnf_info pnf[MAX_ENB];
 static pnf_info pnf_nr;
-static pthread_t pnf_start_pthread;
+static pthread_t pnf_start_pthread[MAX_ENB];
 static pthread_t pnf_nr_start_pthread;
 
 void *pnf_allocate(size_t size)
@@ -490,7 +490,7 @@ int param_request(nfapi_pnf_config_t *config, nfapi_pnf_phy_config_t *phy, nfapi
     nfapi_resp.num_tlv++;
     // P7 PNF Port
     nfapi_resp.nfapi_config.p7_pnf_port.tl.tag = NFAPI_NFAPI_P7_PNF_PORT_TAG;
-    nfapi_resp.nfapi_config.p7_pnf_port.value = 32123; // DJP - hard code alert!!!! FIXME TODO
+    nfapi_resp.nfapi_config.p7_pnf_port.value = pnf->phys[0].udp.rx_port;
     nfapi_resp.num_tlv++;
     nfapi_pnf_param_resp(config, &nfapi_resp);
     NFAPI_TRACE(NFAPI_TRACE_DEBUG, "[PNF] Sent NFAPI_PARAM_RESPONSE phy_id:%d number_of_tlvs:%u\n", req->header.phy_id, nfapi_resp.num_tlv);
@@ -1749,10 +1749,10 @@ int start_request(nfapi_pnf_config_t *config, nfapi_pnf_phy_config_t *phy, nfapi
     phy_info *phy_info = pnf->phys;
     nfapi_pnf_p7_config_t *p7_config = nfapi_pnf_p7_config_create();
     p7_config->phy_id = phy->phy_id;
+    p7_config->pnf_id = phy_info->pnf_id;
     p7_config->remote_p7_port = phy_info->remote_port;
     p7_config->remote_p7_addr = phy_info->remote_addr;
-    p7_config->local_p7_port = 32123; // DJP - good grief cannot seem to get the right answer phy_info->local_port;
-    //p7_config->local_p7_port = phy_info->udp.rx_port;
+    p7_config->local_p7_port = phy_info->udp.rx_port;
     //DJP p7_config->local_p7_addr = (char*)phy_info->local_addr.c_str();
     p7_config->local_p7_addr = phy_info->local_addr;
     NFAPI_TRACE(NFAPI_TRACE_DEBUG, "[PNF] P7 remote:%s:%d local:%s:%d\n", p7_config->remote_p7_addr, p7_config->remote_p7_port,
@@ -1812,7 +1812,7 @@ int start_request(nfapi_pnf_config_t *config, nfapi_pnf_phy_config_t *phy, nfapi
 
     NFAPI_TRACE(NFAPI_TRACE_INFO, "[PNF] Calling l1_north_init_eNB() %s\n", __FUNCTION__);
     NFAPI_TRACE(NFAPI_TRACE_INFO, "[PNF] DJP - HACK - Set p7_config global ready for subframe ind%s\n", __FUNCTION__);
-    p7_config_g = p7_config;
+    p7_config_g[p7_config->pnf_id] = p7_config;
 
     NFAPI_TRACE(NFAPI_TRACE_DEBUG, "[PNF] OAI eNB/RU configured\n");
     NFAPI_TRACE(NFAPI_TRACE_DEBUG, "[PNF] About to call init_eNB_afterRU()\n");
@@ -2314,23 +2314,24 @@ void configure_nr_nfapi_pnf(const char *vnf_ip_addr, int vnf_p5_port, const char
 
 }
 
-void configure_nfapi_pnf(const char *vnf_ip_addr, int vnf_p5_port, const char *pnf_ip_addr, int pnf_p7_port,
+void configure_nfapi_pnf(int id, const char *vnf_ip_addr, int vnf_p5_port, const char *pnf_ip_addr, int pnf_p7_port,
                          int vnf_p7_port)
 {
     nfapi_pnf_config_t *config = nfapi_pnf_config_create();
     config->vnf_ip_addr = vnf_ip_addr;
     config->vnf_p5_port = vnf_p5_port;
-    pnf.phys[0].udp.enabled = 1;
-    pnf.phys[0].udp.rx_port = pnf_p7_port;
-    pnf.phys[0].udp.tx_port = vnf_p7_port;
-    strcpy(pnf.phys[0].udp.tx_addr, vnf_ip_addr);
-    strcpy(pnf.phys[0].local_addr, pnf_ip_addr);
+    pnf[id].phys[0].udp.enabled = 1;
+    pnf[id].phys[0].udp.rx_port = pnf_p7_port;
+    pnf[id].phys[0].udp.tx_port = vnf_p7_port;
+    pnf[id].phys[0].pnf_id = id;
+    strcpy(pnf[id].phys[0].udp.tx_addr, vnf_ip_addr);
+    strcpy(pnf[id].phys[0].local_addr, pnf_ip_addr);
     NFAPI_TRACE(NFAPI_TRACE_DEBUG, "%s() VNF:%s:%d PNF_PHY[addr:%s UDP:tx_addr:%s:%d rx:%d]\n",
            __FUNCTION__,
            config->vnf_ip_addr, config->vnf_p5_port,
-           pnf.phys[0].local_addr,
-           pnf.phys[0].udp.tx_addr, pnf.phys[0].udp.tx_port,
-           pnf.phys[0].udp.rx_port);
+           pnf[id].phys[0].local_addr,
+           pnf[id].phys[0].udp.tx_addr, pnf[id].phys[0].udp.tx_port,
+           pnf[id].phys[0].udp.rx_port);
     config->pnf_param_req = &pnf_param_request;
     config->pnf_config_req = &pnf_config_request;
     config->pnf_start_req = &pnf_start_request;
@@ -2345,14 +2346,14 @@ void configure_nfapi_pnf(const char *vnf_ip_addr, int vnf_p5_port, const char *p
     config->system_information_schedule_req = &system_information_schedule_request;
     config->system_information_req = &system_information_request;
     config->nmm_stop_req = &nmm_stop_request;
-    config->user_data = &pnf;
+    config->user_data = &pnf[id];
     // To allow custom vendor extentions to be added to nfapi
     NFAPI_TRACE(NFAPI_TRACE_INFO, "[PNF] Creating PNF NFAPI start thread %s\n", __FUNCTION__);
-    if (pthread_create(&pnf_start_pthread, NULL, &pnf_start_thread, config) != 0)
+    if (pthread_create(&pnf_start_pthread[id], NULL, &pnf_start_thread, config) != 0)
     {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "pthread_create: %s\n", strerror(errno));
     }
-    if (pthread_setname_np(pnf_start_pthread, "NFAPI_PNF") != 0)
+    if (pthread_setname_np(pnf_start_pthread[id], "NFAPI_PNF") != 0)
     {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "pthread_setname_np: %s\n", strerror(errno));
     }
@@ -2370,10 +2371,10 @@ void configure_nfapi_pnf(const char *vnf_ip_addr, int vnf_p5_port, const char *p
     */
 }
 
-void oai_subframe_ind(uint16_t sfn, uint16_t sf)
+void oai_subframe_ind(int id, uint16_t sfn, uint16_t sf)
 {
     //TODO FIXME - HACK - DJP - using a global to bodge it in
-    if (p7_config_g != NULL)
+    if (p7_config_g[id] != NULL)
     {
         uint16_t sfn_sf_tx = sfn << 4 | sf;
 
@@ -2385,7 +2386,7 @@ void oai_subframe_ind(uint16_t sfn, uint16_t sf)
                         ts.tv_sec, ts.tv_nsec, sfn, sf, NFAPI_SFNSF2DEC(sfn_sf_tx));
         }
 
-        int subframe_ret = nfapi_pnf_p7_subframe_ind(p7_config_g, p7_config_g->phy_id, sfn_sf_tx);
+        int subframe_ret = nfapi_pnf_p7_subframe_ind(p7_config_g[id], p7_config_g[id]->phy_id, sfn_sf_tx);
 
         if (subframe_ret)
         {
@@ -2622,7 +2623,7 @@ static void warn_if_different_slots(const char *label,
     nfapi_vendor_extension_tlv_t vendor_extension (typedef nfapi_tl_t*)
 */
 
-static void oai_subframe_aggregate_rach_ind(subframe_msgs_t *msgs)
+static void oai_subframe_aggregate_rach_ind(int id, subframe_msgs_t *msgs)
 {
     /* Currently we select the first RACH and ignore others.
        We could have various policies to select one RACH over
@@ -2640,7 +2641,7 @@ static void oai_subframe_aggregate_rach_ind(subframe_msgs_t *msgs)
             continue;
         }
         ind.sfn_sf = sfn_sf_add(ind.sfn_sf, 5);
-        oai_nfapi_rach_ind(&ind);
+        oai_nfapi_rach_ind(id, &ind);
     }
 }
 
@@ -2725,7 +2726,7 @@ static void oai_slot_aggregate_rach_ind(slot_msgs_t *msgs)
         nfapi_vendor_extension_tlv_t vendor_extension (typedef nfapi_tl_t*)
 */
 
-static void oai_subframe_aggregate_crc_ind(subframe_msgs_t *msgs)
+static void oai_subframe_aggregate_crc_ind(int id, subframe_msgs_t *msgs)
 {
     assert(msgs->num_msgs > 0);
     nfapi_crc_indication_t agg;
@@ -2774,7 +2775,7 @@ static void oai_subframe_aggregate_crc_ind(subframe_msgs_t *msgs)
         }
     }
 
-    oai_nfapi_crc_indication(&agg);
+    oai_nfapi_crc_indication(id, &agg);
     free(agg.crc_indication_body.crc_pdu_list); // Should actually be nfapi_vnf_p7_release_msg
 }
 
@@ -2928,7 +2929,7 @@ static void oai_slot_aggregate_crc_ind(slot_msgs_t *msgs)
 // }
 
 
-static void oai_subframe_aggregate_rx_ind(subframe_msgs_t *msgs)
+static void oai_subframe_aggregate_rx_ind(int id, subframe_msgs_t *msgs)
 {
     assert(msgs->num_msgs > 0);
     nfapi_rx_indication_t agg;
@@ -3018,7 +3019,7 @@ static void oai_subframe_aggregate_rx_ind(subframe_msgs_t *msgs)
         }
     }
 
-    oai_nfapi_rx_ind(&agg);
+    oai_nfapi_rx_ind(id, &agg);
     free(agg.rx_indication_body.rx_pdu_list); // Should actually be nfapi_vnf_p7_release_msg
 }
 
@@ -3183,7 +3184,7 @@ static void oai_slot_aggregate_rx_data_ind(slot_msgs_t *msgs)
     nfapi_vendor_extension_tlv_t vendor_extension (typedef nfapi_tl_t*)
 */
 
-static void oai_subframe_aggregate_cqi_ind(subframe_msgs_t *msgs)
+static void oai_subframe_aggregate_cqi_ind(int id, subframe_msgs_t *msgs)
 {
     assert(msgs->num_msgs > 0);
     nfapi_cqi_indication_t agg;
@@ -3260,7 +3261,7 @@ static void oai_subframe_aggregate_cqi_ind(subframe_msgs_t *msgs)
         }
     }
 
-    oai_nfapi_cqi_indication(&agg);
+    oai_nfapi_cqi_indication(id, &agg);
     free(agg.cqi_indication_body.cqi_pdu_list); // Should actually be nfapi_vnf_p7_release_msg
     free(agg.cqi_indication_body.cqi_raw_pdu_list);
 }
@@ -3537,7 +3538,7 @@ static void oai_slot_aggregate_uci_ind(slot_msgs_t *msgs)
     nfapi_vendor_extension_tlv_t vendor_extension (typedef nfapi_tl_t*)
 */
 
-static void oai_subframe_aggregate_harq_ind(subframe_msgs_t *msgs)
+static void oai_subframe_aggregate_harq_ind(int id, subframe_msgs_t *msgs)
 {
     assert(msgs->num_msgs > 0);
     nfapi_harq_indication_t agg;
@@ -3586,7 +3587,7 @@ static void oai_subframe_aggregate_harq_ind(subframe_msgs_t *msgs)
         }
     }
 
-    oai_nfapi_harq_indication(&agg);
+    oai_nfapi_harq_indication(id, &agg);
     free(agg.harq_indication_body.harq_pdu_list); // Should actually be nfapi_vnf_p7_release_msg
 }
 
@@ -3616,7 +3617,7 @@ static void oai_subframe_aggregate_harq_ind(subframe_msgs_t *msgs)
     nfapi_vendor_extension_tlv_t vendor_extension (typedef nfapi_tl_t*)
 */
 
-static void oai_subframe_aggregate_sr_ind(subframe_msgs_t *msgs)
+static void oai_subframe_aggregate_sr_ind(int id, subframe_msgs_t *msgs)
 {
     assert(msgs->num_msgs > 0);
     nfapi_sr_indication_t agg;
@@ -3665,7 +3666,7 @@ static void oai_subframe_aggregate_sr_ind(subframe_msgs_t *msgs)
         }
     }
 
-    oai_nfapi_sr_indication(&agg);
+    oai_nfapi_sr_indication(id, &agg);
     free(agg.sr_indication_body.sr_pdu_list); // Should actually be nfapi_vnf_p7_release_msg
 }
 
@@ -3745,7 +3746,7 @@ static void oai_slot_aggregate_srs_ind(slot_msgs_t *msgs)
     free(agg.pdu_list); // Should actually be nfapi_vnf_p7_release_msg
 }
 
-static void oai_subframe_aggregate_message_id(uint16_t msg_id, subframe_msgs_t *msgs)
+static void oai_subframe_aggregate_message_id(int id, uint16_t msg_id, subframe_msgs_t *msgs)
 {
     assert(msgs->num_msgs > 0);
     assert(msgs->msgs[0] != NULL);
@@ -3757,22 +3758,22 @@ static void oai_subframe_aggregate_message_id(uint16_t msg_id, subframe_msgs_t *
     switch (msg_id)
     {
     case NFAPI_RACH_INDICATION:
-        oai_subframe_aggregate_rach_ind(msgs);
+        oai_subframe_aggregate_rach_ind(id, msgs);
         break;
     case NFAPI_CRC_INDICATION:
-        oai_subframe_aggregate_crc_ind(msgs);
+        oai_subframe_aggregate_crc_ind(id, msgs);
         break;
     case NFAPI_RX_ULSCH_INDICATION:
-        oai_subframe_aggregate_rx_ind(msgs);
+        oai_subframe_aggregate_rx_ind(id, msgs);
         break;
     case NFAPI_RX_CQI_INDICATION:
-        oai_subframe_aggregate_cqi_ind(msgs);
+        oai_subframe_aggregate_cqi_ind(id, msgs);
         break;
     case NFAPI_HARQ_INDICATION:
-        oai_subframe_aggregate_harq_ind(msgs);
+        oai_subframe_aggregate_harq_ind(id, msgs);
         break;
     case NFAPI_RX_SR_INDICATION:
-        oai_subframe_aggregate_sr_ind(msgs);
+        oai_subframe_aggregate_sr_ind(id, msgs);
         break;
     default:
         return;
@@ -3782,7 +3783,7 @@ static void oai_subframe_aggregate_message_id(uint16_t msg_id, subframe_msgs_t *
 /*
     subframe_msgs is a pointer to an array of num_ues
 */
-static void oai_subframe_aggregate_messages(subframe_msgs_t *subframe_msgs)
+static void oai_subframe_aggregate_messages(int id, subframe_msgs_t *subframe_msgs)
 {
     for (;;)
     {
@@ -3824,7 +3825,7 @@ static void oai_subframe_aggregate_messages(subframe_msgs_t *subframe_msgs)
         {
             break;
         }
-        oai_subframe_aggregate_message_id(found_msg_id, &msgs_by_id);
+        oai_subframe_aggregate_message_id(id, found_msg_id, &msgs_by_id);
 
         for (int k = 0; k < msgs_by_id.num_msgs; k++)
         {
@@ -4237,7 +4238,7 @@ void *oai_subframe_task(void *context)
     uint16_t sf = 0;
     bool are_queues_empty = true;
     softmodem_mode_t softmodem_mode = ((struct oai_task_args*)context)->softmodem_mode;
-    int enb_id = ((struct oai_task_args*)context)->node_id;
+    int id = ((struct oai_task_args*)context)->node_id;
     NFAPI_TRACE(NFAPI_TRACE_INFO, "Subframe Task thread");
     while (true)
     {
@@ -4246,7 +4247,7 @@ void *oai_subframe_task(void *context)
 
         uint64_t iteration_start = clock_usec();
 
-        transfer_downstream_sfn_sf_to_proxy(sfn_sf_tx); // send to oai UE
+        transfer_downstream_sfn_sf_to_proxy(id, sfn_sf_tx); // send to oai UE
         NFAPI_TRACE(NFAPI_TRACE_DEBUG, "Frame %u Subframe %u sent to OAI ue", sfn_sf_tx >> 4,
                     sfn_sf_tx & 0XF);
 
@@ -4256,7 +4257,7 @@ void *oai_subframe_task(void *context)
         }
 
         uint64_t poll_end = clock_usec();
-        oai_subframe_ind(sfn, sf);
+        oai_subframe_ind(id, sfn, sf);
         uint64_t subframe_sent = clock_usec();
 
         /*
@@ -4264,9 +4265,9 @@ void *oai_subframe_task(void *context)
         */
         subframe_msgs_t subframe_msgs[MAX_UES];
         memset(subframe_msgs, 0, sizeof(subframe_msgs));
-        are_queues_empty = dequeue_ue_msgs(enb_id, subframe_msgs, sfn_sf_tx);
+        are_queues_empty = dequeue_ue_msgs(id, subframe_msgs, sfn_sf_tx);
 
-        oai_subframe_aggregate_messages(subframe_msgs);
+        oai_subframe_aggregate_messages(id, subframe_msgs);
 
         if (softmodem_mode == SOFTMODEM_NSA)
         {
@@ -4454,7 +4455,7 @@ void handle_nr_slot_ind(uint16_t sfn, uint16_t slot) {
 }
 */
 
-int oai_nfapi_rach_ind(nfapi_rach_indication_t *rach_ind)
+int oai_nfapi_rach_ind(int id, nfapi_rach_indication_t *rach_ind)
 {
 
     rach_ind->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
@@ -4462,16 +4463,16 @@ int oai_nfapi_rach_ind(nfapi_rach_indication_t *rach_ind)
     NFAPI_TRACE(NFAPI_TRACE_INFO, "Sent the rach to eNB sf: %u sfn : %u num of preambles: %u",
                rach_ind->sfn_sf & 0xF, rach_ind->sfn_sf >> 4, rach_ind->rach_indication_body.number_of_preambles);
 
-    return nfapi_pnf_p7_rach_ind(p7_config_g, rach_ind);
+    return nfapi_pnf_p7_rach_ind(p7_config_g[id], rach_ind);
 }
 
-int oai_nfapi_harq_indication(nfapi_harq_indication_t *harq_ind)
+int oai_nfapi_harq_indication(int id, nfapi_harq_indication_t *harq_ind)
 {
     harq_ind->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
     harq_ind->header.message_id = NFAPI_HARQ_INDICATION;
     NFAPI_TRACE(NFAPI_TRACE_INFO, "sfn_sf:%d number_of_harqs:%d\n", NFAPI_SFNSF2DEC(harq_ind->sfn_sf),
                harq_ind->harq_indication_body.number_of_harqs);
-    int retval = nfapi_pnf_p7_harq_ind(p7_config_g, harq_ind);
+    int retval = nfapi_pnf_p7_harq_ind(p7_config_g[id], harq_ind);
 
     if (retval != 0)
     {
@@ -4483,16 +4484,16 @@ int oai_nfapi_harq_indication(nfapi_harq_indication_t *harq_ind)
     return retval;
 }
 
-int oai_nfapi_crc_indication(nfapi_crc_indication_t *crc_ind) // msg 3
+int oai_nfapi_crc_indication(int id, nfapi_crc_indication_t *crc_ind) // msg 3
 {
 
     crc_ind->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
     crc_ind->header.message_id = NFAPI_CRC_INDICATION;
 
-    return nfapi_pnf_p7_crc_ind(p7_config_g, crc_ind);
+    return nfapi_pnf_p7_crc_ind(p7_config_g[id], crc_ind);
 }
 
-int oai_nfapi_cqi_indication(nfapi_cqi_indication_t *ind) // maybe msg 3
+int oai_nfapi_cqi_indication(int id, nfapi_cqi_indication_t *ind) // maybe msg 3
 {
     ind->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
     ind->header.message_id = NFAPI_RX_CQI_INDICATION;
@@ -4511,10 +4512,10 @@ int oai_nfapi_cqi_indication(nfapi_cqi_indication_t *ind) // maybe msg 3
         }
     }
 
-    return nfapi_pnf_p7_cqi_ind(p7_config_g, ind);
+    return nfapi_pnf_p7_cqi_ind(p7_config_g[id], ind);
 }
 
-int oai_nfapi_rx_ind(nfapi_rx_indication_t *ind) // msg 3
+int oai_nfapi_rx_ind(int id, nfapi_rx_indication_t *ind) // msg 3
 {
 
     ind->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
@@ -4540,7 +4541,7 @@ int oai_nfapi_rx_ind(nfapi_rx_indication_t *ind) // msg 3
         return -1;
     }
 
-    if (nfapi_pnf_p7_rx_ind(p7_config_g, ind) != 0)
+    if (nfapi_pnf_p7_rx_ind(p7_config_g[id], ind) != 0)
     {
         NFAPI_TRACE(NFAPI_TRACE_ERROR, "Failed to send the RX_IND for SFN.SF %u.%u",
                     ind->sfn_sf >> 4, ind->sfn_sf & 15);
@@ -4565,11 +4566,11 @@ int oai_nfapi_rx_ind(nfapi_rx_indication_t *ind) // msg 3
     return 0;
 }
 
-int oai_nfapi_sr_indication(nfapi_sr_indication_t *ind)
+int oai_nfapi_sr_indication(int id, nfapi_sr_indication_t *ind)
 {
 
     ind->header.phy_id = 1; // DJP HACK TODO FIXME - need to pass this around!!!!
-    int retval = nfapi_pnf_p7_sr_ind(p7_config_g, ind);
+    int retval = nfapi_pnf_p7_sr_ind(p7_config_g[id], ind);
     return retval;
 }
 

--- a/src/nfapi_pnf.h
+++ b/src/nfapi_pnf.h
@@ -243,12 +243,12 @@ void *oai_slot_task(void *context);
 void oai_subframe_init(int enb_id);
 void oai_slot_init();
 void oai_subframe_flush_msgs_from_ue();
-void oai_subframe_handle_msg_from_ue(int enb_id, const void *msg, size_t len, uint16_t nem_id);
+void oai_subframe_handle_msg_from_ue(uint16_t enb_id, const void *msg, size_t len, uint16_t nem_id);
 void oai_slot_handle_msg_from_ue(const void *msg, size_t len, uint16_t nem_id);
 
-void transfer_downstream_nfapi_msg_to_proxy(int id, void *msg);
+void transfer_downstream_nfapi_msg_to_proxy(uint16_t id, void *msg);
 void transfer_downstream_nfapi_msg_to_nr_proxy(void *msg);
-void transfer_downstream_sfn_sf_to_proxy(int id, uint16_t sfn_sf);
+void transfer_downstream_sfn_sf_to_proxy(uint16_t id, uint16_t sfn_sf);
 void transfer_downstream_sfn_slot_to_proxy(uint16_t sfn_slot);
 
 uint16_t sfn_sf_add(uint16_t a, uint16_t add_val);

--- a/src/nfapi_pnf.h
+++ b/src/nfapi_pnf.h
@@ -84,6 +84,7 @@ typedef struct
 {
     uint16_t index;
     uint16_t id;
+    int pnf_id;
     uint8_t rfs[2];
     uint8_t excluded_rfs[2];
 
@@ -189,12 +190,12 @@ typedef struct slot_msgs_t
     message_buffer_t *msgs[MAX_SLOT_MSGS];
 } slot_msgs_t;
 
-int oai_nfapi_rach_ind(nfapi_rach_indication_t *rach_ind);
-int oai_nfapi_harq_indication(nfapi_harq_indication_t *harq_ind);
-int oai_nfapi_crc_indication(nfapi_crc_indication_t *crc_ind);
-int oai_nfapi_cqi_indication(nfapi_cqi_indication_t *ind);
-int oai_nfapi_rx_ind(nfapi_rx_indication_t *ind);
-int oai_nfapi_sr_indication(nfapi_sr_indication_t *ind);
+int oai_nfapi_rach_ind(int id, nfapi_rach_indication_t *rach_ind);
+int oai_nfapi_harq_indication(int id, nfapi_harq_indication_t *harq_ind);
+int oai_nfapi_crc_indication(int id, nfapi_crc_indication_t *crc_ind);
+int oai_nfapi_cqi_indication(int id, nfapi_cqi_indication_t *ind);
+int oai_nfapi_rx_ind(int id, nfapi_rx_indication_t *ind);
+int oai_nfapi_sr_indication(int id, nfapi_sr_indication_t *ind);
 
 int oai_nfapi_nr_rach_indication(nfapi_nr_rach_indication_t *ind);
 int oai_nfapi_nr_rx_data_indication(nfapi_nr_rx_data_indication_t *ind);
@@ -202,10 +203,10 @@ int oai_nfapi_nr_crc_indication(nfapi_nr_crc_indication_t *ind);
 int oai_nfapi_nr_srs_indication(nfapi_nr_srs_indication_t *ind);
 int oai_nfapi_nr_uci_indication(nfapi_nr_uci_indication_t *ind);
 
-void oai_subframe_ind(uint16_t sfn, uint16_t sf);
+void oai_subframe_ind(int id, uint16_t sfn, uint16_t sf);
 void oai_slot_ind(uint16_t sfn, uint16_t slot);
 
-void configure_nfapi_pnf(const char *vnf_ip_addr, int vnf_p5_port, const char *pnf_ip_addr, int pnf_p7_port,
+void configure_nfapi_pnf(int config_id, const char *vnf_ip_addr, int vnf_p5_port, const char *pnf_ip_addr, int pnf_p7_port,
                          int vnf_p7_port);
 void configure_nr_nfapi_pnf(const char *vnf_ip_addr, int vnf_p5_port, const char *pnf_ip_addr, int pnf_p7_port, int vnf_p7_port);
 
@@ -245,9 +246,9 @@ void oai_subframe_flush_msgs_from_ue();
 void oai_subframe_handle_msg_from_ue(int enb_id, const void *msg, size_t len, uint16_t nem_id);
 void oai_slot_handle_msg_from_ue(const void *msg, size_t len, uint16_t nem_id);
 
-void transfer_downstream_nfapi_msg_to_proxy(void *msg);
+void transfer_downstream_nfapi_msg_to_proxy(int id, void *msg);
 void transfer_downstream_nfapi_msg_to_nr_proxy(void *msg);
-void transfer_downstream_sfn_sf_to_proxy(uint16_t sfn_sf);
+void transfer_downstream_sfn_sf_to_proxy(int id, uint16_t sfn_sf);
 void transfer_downstream_sfn_slot_to_proxy(uint16_t sfn_slot);
 
 uint16_t sfn_sf_add(uint16_t a, uint16_t add_val);

--- a/src/nfapi_pnf.h
+++ b/src/nfapi_pnf.h
@@ -239,10 +239,10 @@ void handle_nr_nfapi_ssb_pdu(PHY_VARS_gNB *gNB,int frame,int slot,
 
 void *oai_subframe_task(void *context);
 void *oai_slot_task(void *context);
-void oai_subframe_init();
+void oai_subframe_init(int enb_id);
 void oai_slot_init();
 void oai_subframe_flush_msgs_from_ue();
-void oai_subframe_handle_msg_from_ue(const void *msg, size_t len, uint16_t nem_id);
+void oai_subframe_handle_msg_from_ue(int enb_id, const void *msg, size_t len, uint16_t nem_id);
 void oai_slot_handle_msg_from_ue(const void *msg, size_t len, uint16_t nem_id);
 
 void transfer_downstream_nfapi_msg_to_proxy(void *msg);
@@ -258,11 +258,12 @@ int get_slot_delta(uint16_t a, uint16_t b);
 uint16_t sfn_sf_subtract(uint16_t a, uint16_t sub_val);
 
 
-bool dequeue_ue_msgs(subframe_msgs_t *subframe_msgs, uint16_t sfn_sf_tx);
+bool dequeue_ue_msgs(int enb_id, subframe_msgs_t *subframe_msgs, uint16_t sfn_sf_tx);
 void add_sleep_time(uint64_t start, uint64_t poll, uint64_t send, uint64_t agg);
 
 extern int num_ues;
 
+#define MAX_ENB 2
 #define MAX_UES 64
 
 #ifdef __cplusplus

--- a/src/nr_proxy.h
+++ b/src/nr_proxy.h
@@ -46,7 +46,6 @@ private:
     int vnf_p7port = -1;
     int pnf_p7port = -1;
 
-    std::uint16_t u16SequenceNumber_ = 0;
     struct sockaddr_in address_tx_;
     struct sockaddr_in address_rx_;
     int ue_tx_socket_ = -1;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -101,7 +101,13 @@ int main(int argc, char *argv[])
     {
     case 0:
         // Use all the default addresses
-        enb_ipaddrs.push_back("127.0.0.1");
+        if (softmodem_mode == SOFTMODEM_LTE_HANDOVER)
+        {
+            enb_ipaddrs.push_back("127.0.0.1");
+            enb_ipaddrs.push_back("127.0.0.2");
+        }
+        else
+            enb_ipaddrs.push_back("127.0.0.1");
         break;
     case 3:
         if (softmodem_mode != SOFTMODEM_LTE && softmodem_mode != SOFTMODEM_NR)
@@ -168,6 +174,7 @@ int main(int argc, char *argv[])
             Multi_UE_Proxy lte_target_proxy(1, ues, enb_ipaddrs[1], proxy_ipaddr, ue_ipaddr);
 
             std::thread lte_source_th( &Multi_UE_Proxy::start, &lte_source_proxy, softmodem_mode);
+            sleep(1);
             std::thread lte_target_th( &Multi_UE_Proxy::start, &lte_target_proxy, softmodem_mode);
 
             lte_source_th.join();

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -164,21 +164,14 @@ int main(int argc, char *argv[])
     case SOFTMODEM_LTE:
         {
             // Should pass multiple ip addresses by using vector or array.
-            Multi_UE_Proxy lte_proxy(0, ues, enb_ipaddrs[0], proxy_ipaddr, ue_ipaddr);
+            Multi_UE_Proxy lte_proxy(ues, enb_ipaddrs, proxy_ipaddr, ue_ipaddr);
             lte_proxy.start(softmodem_mode);
         }
         break;
     case SOFTMODEM_LTE_HANDOVER:
         {
-            Multi_UE_Proxy lte_source_proxy(0, ues, enb_ipaddrs[0], proxy_ipaddr, ue_ipaddr);
-            Multi_UE_Proxy lte_target_proxy(1, ues, enb_ipaddrs[1], proxy_ipaddr, ue_ipaddr);
-
-            std::thread lte_source_th( &Multi_UE_Proxy::start, &lte_source_proxy, softmodem_mode);
-            sleep(1);
-            std::thread lte_target_th( &Multi_UE_Proxy::start, &lte_target_proxy, softmodem_mode);
-
-            lte_source_th.join();
-            lte_target_th.join();
+            Multi_UE_Proxy lte_proxy(ues, enb_ipaddrs, proxy_ipaddr, ue_ipaddr);
+            lte_proxy.start(softmodem_mode);
         }
         break;
     case SOFTMODEM_NR:
@@ -189,7 +182,7 @@ int main(int argc, char *argv[])
         break;
     case SOFTMODEM_NSA:
         {
-            Multi_UE_Proxy lte_proxy(0, ues, enb_ipaddrs[0], proxy_ipaddr, ue_ipaddr);
+            Multi_UE_Proxy lte_proxy(ues, enb_ipaddrs, proxy_ipaddr, ue_ipaddr);
             Multi_UE_NR_Proxy nr_proxy(ues, gnb_ipaddr, proxy_ipaddr, ue_ipaddr);
 
             std::thread lte_th( &Multi_UE_Proxy::start, &lte_proxy, softmodem_mode);

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -61,6 +61,11 @@ int main(int argc, char *argv[])
             softmodem_mode = SOFTMODEM_LTE;
             continue;
         }
+        if (arg == "--lte_handover")
+        {
+            softmodem_mode = SOFTMODEM_LTE_HANDOVER;
+            continue;
+        }
         if (arg == "--nr")
         {
             softmodem_mode = SOFTMODEM_NR;
@@ -89,33 +94,44 @@ int main(int argc, char *argv[])
     }
 
     std::string ue_ipaddr = "127.0.0.1";
-    std::string enb_ipaddr = "127.0.0.1";
-    std::string gnb_ipaddr = "127.0.0.2";
     std::string proxy_ipaddr = "127.0.0.1";
+    std::string gnb_ipaddr = "127.0.0.2";
+    std::vector<std::string> enb_ipaddrs;
     switch (ipaddrs.size())
     {
     case 0:
         // Use all the default addresses
+        enb_ipaddrs.push_back("127.0.0.1");
         break;
     case 3:
         if (softmodem_mode != SOFTMODEM_LTE && softmodem_mode != SOFTMODEM_NR)
         {
             try_help("Wrong number of IP addresses");
         }
-        enb_ipaddr = ipaddrs[0];
+        enb_ipaddrs.push_back(ipaddrs[0]);
         gnb_ipaddr = ipaddrs[0];
         proxy_ipaddr = ipaddrs[1];
         ue_ipaddr = ipaddrs[2];
         break;
     case 4:
-        if (softmodem_mode != SOFTMODEM_NSA)
+        if (softmodem_mode == SOFTMODEM_NSA)
+        {
+            enb_ipaddrs.push_back(ipaddrs[0]);
+            gnb_ipaddr = ipaddrs[1];
+            proxy_ipaddr = ipaddrs[2];
+            ue_ipaddr = ipaddrs[3];
+        }
+        else if (softmodem_mode == SOFTMODEM_LTE_HANDOVER)
+        {
+            enb_ipaddrs.push_back(ipaddrs[0]);
+            enb_ipaddrs.push_back(ipaddrs[1]);
+            proxy_ipaddr = ipaddrs[2];
+            ue_ipaddr = ipaddrs[3];
+        }
+        else
         {
             try_help("Wrong number of IP addresses");
         }
-        enb_ipaddr = ipaddrs[0];
-        gnb_ipaddr = ipaddrs[1];
-        proxy_ipaddr = ipaddrs[2];
-        ue_ipaddr = ipaddrs[3];
         break;
     default:
         try_help("Invalid number of IP addresses");
@@ -141,8 +157,21 @@ int main(int argc, char *argv[])
     {
     case SOFTMODEM_LTE:
         {
-            Multi_UE_Proxy lte_proxy(ues, enb_ipaddr, proxy_ipaddr, ue_ipaddr);
+            // Should pass multiple ip addresses by using vector or array.
+            Multi_UE_Proxy lte_proxy(0, ues, enb_ipaddrs[0], proxy_ipaddr, ue_ipaddr);
             lte_proxy.start(softmodem_mode);
+        }
+        break;
+    case SOFTMODEM_LTE_HANDOVER:
+        {
+            Multi_UE_Proxy lte_source_proxy(0, ues, enb_ipaddrs[0], proxy_ipaddr, ue_ipaddr);
+            Multi_UE_Proxy lte_target_proxy(1, ues, enb_ipaddrs[1], proxy_ipaddr, ue_ipaddr);
+
+            std::thread lte_source_th( &Multi_UE_Proxy::start, &lte_source_proxy, softmodem_mode);
+            std::thread lte_target_th( &Multi_UE_Proxy::start, &lte_target_proxy, softmodem_mode);
+
+            lte_source_th.join();
+            lte_target_th.join();
         }
         break;
     case SOFTMODEM_NR:
@@ -153,7 +182,7 @@ int main(int argc, char *argv[])
         break;
     case SOFTMODEM_NSA:
         {
-            Multi_UE_Proxy lte_proxy(ues, enb_ipaddr, proxy_ipaddr, ue_ipaddr);
+            Multi_UE_Proxy lte_proxy(0, ues, enb_ipaddrs[0], proxy_ipaddr, ue_ipaddr);
             Multi_UE_NR_Proxy nr_proxy(ues, gnb_ipaddr, proxy_ipaddr, ue_ipaddr);
 
             std::thread lte_th( &Multi_UE_Proxy::start, &lte_proxy, softmodem_mode);
@@ -176,11 +205,12 @@ void show_usage()
               << "  Number of IP address:\n"
               << "    0 - use the loopback interface (default)\n"
               << "    3 - ENB/GNB proxy UE (for LTE and NR modes)\n"
-              << "    4 - ENB GNB proxy UE (for NSA mode)\n"
+              << "    4 - ENB GNB/ENB proxy UE (for NSA mode or LTE HANDOVER mode)\n"
               << "  Options:\n"
               << "    --lte              Softmodem mode is LTE (default)\n"
               << "    --nr               Softmodem mode is NR\n"
               << "    --nsa              Softmodem mode is NSA\n"
+              << "    --lte_handover     Softmodem mode is LTE HANDOVER\n"
               << "    --max-seconds SEC  Maximum run time (default: " << DEFAULT_MAX_SECONDS << ")\n";
 }
 

--- a/src/proxy.h
+++ b/src/proxy.h
@@ -9,7 +9,14 @@ typedef enum softmodem_mode_t
     SOFTMODEM_LTE,
     SOFTMODEM_NR,
     SOFTMODEM_NSA,
+    SOFTMODEM_LTE_HANDOVER,
 } softmodem_mode_t;
+
+struct oai_task_args
+{
+ softmodem_mode_t softmodem_mode;
+ int node_id;
+};
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
1. Introduction
- Introduced 2 PNFs to handle 2 eNB connections for LTE handover.
- nFAPI is used for the connection between OAI eNBs and OAI UEs.

2. Launching steps: 2 eNBs (source eNB  and target eNB) ->  Proxy -> UEs
- source OAI eNB
```
sudo -E ./ran_build/build/lte-softmodem -O ../ci-scripts/conf_files/episci/proxy_rcc.band7.tm1.nfapi.conf \
 --noS1 --node-number 1 --emulate-l1 \
 --log_config.global_log_options level,nocolor,time,thread_id | tee eNB.log 2>&1

```
- target OAI eNB
```
sudo -E ./ran_build/build/lte-softmodem -O ../ci-scripts/conf_files/episci/proxy_rcc.band7.tm1.nfapi_target.conf \
 --noS1 --node-number 2 --emulate-l1 \
 --log_config.global_log_options level,nocolor,time,thread_id | tee eNB2.log 2>&1
```
- Multi-Ue-Proxy
```
sudo -E ./build/proxy 1 --lte_handover
```
- OAI UE
```
sudo -E ./ran_build/build/lte-uesoftmodem -O ../ci-scripts/conf_files/episci/proxy_ue.nfapi.conf \
 --L2-emul 5 --nokrnmod 1 --noS1 --num-ues 1 --node-number 1 --num-enbs 2 \
 --log_config.global_log_options level,nocolor,time,thread_id | tee UE.log 2>&1
```