### PR TITLE
Improve performance

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ DEPS = $(OBJS:.o=.d)
 
 INC_FLAGS := $(addprefix -I,$(INC_DIRS))
 
-LDFLAGS = -lasan -pthread -lpthread -lz -lsctp -rdynamic
+LDFLAGS = -pthread -lpthread -lz -lsctp -rdynamic
 
 MKDIR_P ?= mkdir -p
 

--- a/open-nFAPI/nfapi/src/nfapi_p7.c
+++ b/open-nFAPI/nfapi/src/nfapi_p7.c
@@ -8368,8 +8368,6 @@ int nfapi_p7_message_unpack(void *pMessageBuf, uint32_t messageBufLen, void *pUn
   }
   printf("\n");
   */
-  // clean the supplied buffer for - tag value blanking
-  (void)memset(pUnpackedBuf, 0, unpackedBufLen);
 
   // process the header
   if(!(pull16(&pReadPackedMessage, &pMessageHeader->phy_id, end) &&
@@ -8598,9 +8596,6 @@ int nfapi_nr_p7_message_unpack(void *pMessageBuf, uint32_t messageBufLen, void *
 		printf("P7 unpack supplied message buffer is too small %d, %d\n", messageBufLen, unpackedBufLen);
 		return -1;
 	}
-
-	// clean the supplied buffer for - tag value blanking
-	(void)memset(pUnpackedBuf, 0, unpackedBufLen);
 
 	// process the header
 	if(!(pull16(&pReadPackedMessage, &pMessageHeader->phy_id, end) &&


### PR DESCRIPTION
the performance in 5G, on smaller machines, is abysmal. To improve this:
- don't load Address Sanitizer: most of the time we don't need it
- do not zero out buffers that are already zeroed out

more info in the commit messages