### PR TITLE
Introduce functionality for running multiple UEs on different IP addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 This repository contains the Multi-UE Proxy to allow UEs to communicate with a
 single eNB (LTE mode), or both an eNB and gNB (NSA mode), or a single gNB
 (SA/NR mode) using the customized OpenAirInterface (OAI) software. The OAI
-code is located at https://gitlab.eurecom.fr/oai/openairinterface5g. The UEs
+code is located at <https://gitlab.eurecom.fr/oai/openairinterface5g>. The UEs
 communicate to the eNB via the bypass PHY layer. Various multi-UE scenarios
 can be tested without the overhead of a PHY layer.
 
@@ -44,34 +44,38 @@ Build and install the EpiSys version of the OAI repository.
 4. git checkout master
 5. If you run the proxy in loopback mode, add the following loopback interface for the VNF in the gNB.
 
-```shell
-sudo ifconfig lo: 127.0.0.2 netmask 255.0.0.0 up
-```
+    ```shell
+    sudo ifconfig lo: 127.0.0.2 netmask 255.0.0.0 up
+    ```
 
 6. Verify that SCTP support is enabled.
 
-```shell
-checksctp
-```
+   ```shell
+   checksctp
+   ```
 
-If SCTP is not supported, then do the following.
+   If SCTP is not supported, then do the following.
 
-```shell
-sudo insmod /lib/modules/$(uname -r)/kernel/net/sctp/sctp.ko
-```
+   ```shell
+   sudo insmod /lib/modules/$(uname -r)/kernel/net/sctp/sctp.ko
+   ```
 
 7. If you plan to use the EPC or 5GCN, be sure to follow the instructions listed in Eurecom's respective repository.
 
-- The EPC is used for both LTE and NSA mode. The 5GCN is used for SA mode.
-- The EPC installation and deployment instructions are found here:
-https://github.com/OPENAIRINTERFACE/openair-epc-fed/blob/master/docs/DEPLOY_HOME_MAGMA_MME.md
-- The 5GCN installation and deployment instructions are found here:
-https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/blob/master/docs/DEPLOY_HOME.md
-- It is critical to update the configuration files in the eNB/gNB/UE/NRUE if running with the 5GCN/EPC.\
-Instructions to update the configuration files are oulined in the EPC/5GCN documentation
-- Each softmodem command will not have the `--noS1` when running with the EPC or 5GCN.
-- The UE and NRUE launch commands will have a `--ue-idx-standalone $node_id` flag added
-when running with the ECP/5GCN to distinguish USIM information for multiple UEs.
+   - The EPC is used for both LTE and NSA mode. The 5GCN is used for SA mode.
+   - The EPC installation and deployment instructions are found here:
+   <https://github.com/OPENAIRINTERFACE/openair-epc-fed/blob/master/docs/DEPLOY_HOME_MAGMA_MME.md>
+   - The 5GCN installation and deployment instructions are found here:
+   <https://gitlab.eurecom.fr/oai/cn5g/oai-cn5g-fed/-/blob/master/docs/DEPLOY_HOME.md>
+   - It is critical to update the configuration files in the eNB/gNB/UE/NRUE if running with the 5GCN/EPC.\
+   Instructions to update the configuration files are oulined in the EPC/5GCN documentation
+   - Each softmodem command will not have the `--noS1` when running with the EPC or 5GCN.
+   - The UE and NRUE launch commands will have a `--ue-idx-standalone $node_id` flag added
+   when running with the ECP/5GCN to distinguish USIM information for multiple UEs.
+
+8. If you plan on running multiple UEs that are not located on the same host or will not all be
+using the same IP address (i.e., Docker containers as UEs), the provided `proxy_testscript.py`
+cannot be used. See the advanced section for details on configuring IP addresses correctly.
 
 ## Build OAI ##
 
@@ -118,7 +122,7 @@ which executables to launch and the necessary flags for each command.  Steps
 `--nsa` flag with `--sa` and only launch NRUE(s), a gNB and the proxy.
 
 | Mode | Executables     | Flags  |
-|------|-----------------|--------|
+| ---- | --------------- | ------ |
 | LTE  | lte-softmodem   | (none) |
 |      | lte-uesoftmodem | (none) |
 | NSA  | lte-softmodem   | --nsa  |
@@ -180,6 +184,8 @@ sudo -E ./ran_build/build/nr-softmodem -O ../ci-scripts/conf_files/episci/proxy_
 
 ### 3. Open a terminal and launch proxy ###
 
+#### 3.a Running UEs on the same host ####
+
 NUMBER_OF_UES is the total number of UEs.
 
 ```shell
@@ -194,6 +200,18 @@ If you do not specify the parameters ending with ipaddr, the default IP addresse
 - gnb_ipaddr = 127.0.0.2
 - proxy_ipaddr = 127.0.0.1
 - ue_ipaddr = 127.0.0.1
+
+#### 3.b Running UEs on different hosts ####
+
+To run UEs on different hosts, a separate IP address must be provided for each UE. The example below shows 3 IP addresses.
+
+NUMBER_OF_UES is the total number of UEs.
+
+```shell
+cd .../oai-lte-multi-ue-proxy
+number_of_ues=3
+sudo -E ./build/proxy $number_of_ues --nsa enb_ipaddr gnb_ipaddr proxy_ipaddr ue1_ipaddr ue2_ipaddr ue3_ipaddr
+```
 
 ### 4. Open a terminal and launch nrUE ###
 

--- a/src/lte_proxy.cc
+++ b/src/lte_proxy.cc
@@ -28,7 +28,7 @@ namespace
     Multi_UE_Proxy *instance;
 }
 
-Multi_UE_Proxy::Multi_UE_Proxy(int num_of_ues,  std::string enb_ip, std::string proxy_ip, std::string ue_ip)
+Multi_UE_Proxy::Multi_UE_Proxy(int num_of_ues,  std::string enb_ip, std::string proxy_ip, std::vector<std::string> ue_ip)
 {
     assert(instance == NULL);
     instance = this;
@@ -63,7 +63,7 @@ void Multi_UE_Proxy::start(softmodem_mode_t softmodem_mode)
     }
 }
 
-void Multi_UE_Proxy::configure(std::string enb_ip, std::string proxy_ip, std::string ue_ip)
+void Multi_UE_Proxy::configure(std::string enb_ip, std::string proxy_ip, std::vector<std::string> ue_ip)
 {
     oai_ue_ipaddr = ue_ip;
     vnf_ipaddr = enb_ip;
@@ -74,13 +74,13 @@ void Multi_UE_Proxy::configure(std::string enb_ip, std::string proxy_ip, std::st
 
     std::cout<<"VNF is on IP Address "<<vnf_ipaddr<<std::endl;
     std::cout<<"PNF is on IP Address "<<pnf_ipaddr<<std::endl;
-    std::cout<<"OAI-UE is on IP Address "<<oai_ue_ipaddr<<std::endl;
 
     for (int ue_idx = 0; ue_idx < num_ues; ue_idx++)
     {
+        std::cout<<"OAI-UE "<<ue_idx<<" is on IP Address "<<oai_ue_ipaddr[ue_idx]<<std::endl;
         int oai_rx_ue_port = 3211 + ue_idx * port_delta;
         int oai_tx_ue_port = 3212 + ue_idx * port_delta;
-        init_oai_socket(oai_ue_ipaddr.c_str(), oai_tx_ue_port, oai_rx_ue_port, ue_idx);
+        init_oai_socket(oai_ue_ipaddr[ue_idx].c_str(), oai_tx_ue_port, oai_rx_ue_port, ue_idx);
     }
 }
 
@@ -200,6 +200,7 @@ void Multi_UE_Proxy::oai_enb_downlink_nfapi_task(void *msg_org)
 
     for(int ue_idx = 0; ue_idx < num_ues; ue_idx++)
     {
+        inet_aton(oai_ue_ipaddr[ue_idx].c_str(), &address_tx_.sin_addr);
         address_tx_.sin_port = htons(3212 + ue_idx * port_delta);
         uint16_t id_=1;
         switch (msg.header.message_id)
@@ -273,6 +274,7 @@ void Multi_UE_Proxy::pack_and_send_downlink_sfn_sf_msg(uint16_t sfn_sf)
 
     for(int ue_idx = 0; ue_idx < num_ues; ue_idx++)
     {
+        inet_aton(oai_ue_ipaddr[ue_idx].c_str(), &address_tx_.sin_addr);
         address_tx_.sin_port = htons(3212 + ue_idx * port_delta);
         assert(ue_tx_socket[ue_idx] > 2);
         if (sendto(ue_tx_socket[ue_idx], &sfn_sf, sizeof(sfn_sf), 0, (const struct sockaddr *) &address_tx_, sizeof(address_tx_)) < 0)

--- a/src/lte_proxy.h
+++ b/src/lte_proxy.h
@@ -46,9 +46,9 @@
 class Multi_UE_Proxy
 {
 public:
-    Multi_UE_Proxy(int num_of_ues, std::string enb_ip, std::string proxy_ip, std::string ue_ip);
+    Multi_UE_Proxy(int num_of_ues, std::string enb_ip, std::string proxy_ip, std::vector<std::string> ue_ip);
     ~Multi_UE_Proxy() = default;
-    void configure(std::string enb_ip, std::string proxy_ip, std::string ue_ip);
+    void configure(std::string enb_ip, std::string proxy_ip, std::vector<std::string> ue_ip);
     int init_oai_socket(const char *addr, int tx_port, int rx_port, int ue_idx);
     void oai_enb_downlink_nfapi_task(void *msg);
     void testcode_tx_packet_to_UE( int ue_tx_socket_);
@@ -59,7 +59,7 @@ public:
     void send_uplink_oai_msg_to_proxy_queue(void *buffer, size_t buflen);
     void start(softmodem_mode_t softmodem_mode);
 private:
-    std::string oai_ue_ipaddr;
+    std::vector<std::string> oai_ue_ipaddr;
     std::string vnf_ipaddr;
     std::string pnf_ipaddr;
     int vnf_p5port = -1;

--- a/src/nr_proxy.h
+++ b/src/nr_proxy.h
@@ -46,9 +46,9 @@
 class Multi_UE_NR_Proxy
 {
 public:
-    Multi_UE_NR_Proxy(int num_of_ues, std::string gnb_ip, std::string proxy_ip, std::string ue_ip);
+    Multi_UE_NR_Proxy(int num_of_ues, std::string gnb_ip, std::string proxy_ip, std::vector<std::string> ue_ip);
     ~Multi_UE_NR_Proxy() = default;
-    void configure(std::string gnb_ip, std::string proxy_ip, std::string ue_ip);
+    void configure(std::string gnb_ip, std::string proxy_ip, std::vector<std::string> ue_ip);
     int init_oai_socket(const char *addr, int tx_port, int rx_port, int ue_idx);
     void oai_gnb_downlink_nfapi_task(void *msg);
     void testcode_tx_packet_to_UE( int ue_tx_socket_);
@@ -59,7 +59,7 @@ public:
     void send_uplink_oai_msg_to_proxy_queue(void *buffer, size_t buflen);
     void start(softmodem_mode_t softmodem_mode);
 private:
-    std::string oai_ue_ipaddr;
+    std::vector<std::string> oai_ue_ipaddr;
     std::string vnf_ipaddr;
     std::string pnf_ipaddr;
     int vnf_p5port = -1;

--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -108,37 +108,63 @@ int main(int argc, char *argv[])
         try_help("unexpected argument: " + arg);
     }
 
-    std::string ue_ipaddr = "127.0.0.1";
+    std::vector<std::string> ue_ipaddr;
     std::string enb_ipaddr = "127.0.0.1";
     std::string gnb_ipaddr = "127.0.0.2";
     std::string proxy_ipaddr = "127.0.0.1";
     switch (ipaddrs.size())
     {
-    case 0:
-        // Use all the default addresses
+    case 0: // If using the default set IP addresses: resize the vector size to match number of UEs
+        ue_ipaddr.resize(ues, "127.0.0.1");
+        std::cout<<ue_ipaddr.size()<<std::endl;
         break;
+    case 1: try_help("Wrong number of IP addresses"); break;
+    case 2: try_help("Wrong number of IP addresses"); break;
     case 3:
-        if (softmodem_mode != SOFTMODEM_LTE && softmodem_mode != SOFTMODEM_NR)
+        if (softmodem_mode == SOFTMODEM_NSA) // NSA mode needs at least 4 IP addrs
         {
             try_help("Wrong number of IP addresses");
         }
         enb_ipaddr = ipaddrs[0];
         gnb_ipaddr = ipaddrs[0];
         proxy_ipaddr = ipaddrs[1];
-        ue_ipaddr = ipaddrs[2];
+        ue_ipaddr[0] = ipaddrs[2];
         break;
     case 4:
-        if (softmodem_mode != SOFTMODEM_NSA)
+        if (softmodem_mode == SOFTMODEM_NSA)
         {
+            enb_ipaddr = ipaddrs[0];
+            gnb_ipaddr = ipaddrs[1];
+            proxy_ipaddr = ipaddrs[2];
+            ue_ipaddr.push_back(ipaddrs[3]);
+        } else if (ues == 2) {
+            enb_ipaddr = ipaddrs[0];
+            gnb_ipaddr = ipaddrs[0];
+            proxy_ipaddr = ipaddrs[1];
+            ue_ipaddr.push_back(ipaddrs[2]);
+            ue_ipaddr.push_back(ipaddrs[3]);
+        } else {
             try_help("Wrong number of IP addresses");
         }
-        enb_ipaddr = ipaddrs[0];
-        gnb_ipaddr = ipaddrs[1];
-        proxy_ipaddr = ipaddrs[2];
-        ue_ipaddr = ipaddrs[3];
         break;
-    default:
-        try_help("Invalid number of IP addresses");
+    default: // Only catches 5+ IP addresses
+        if (softmodem_mode == SOFTMODEM_NR && softmodem_mode == SOFTMODEM_LTE)
+        {
+            enb_ipaddr = ipaddrs[0];
+            gnb_ipaddr = ipaddrs[0];
+            proxy_ipaddr = ipaddrs[1];
+
+            ue_ipaddr.resize(ipaddrs.size() - 2);
+            std::copy(ipaddrs.begin() + 2, ipaddrs.end(), ue_ipaddr.begin());
+        } else if (softmodem_mode == SOFTMODEM_NSA) {
+            enb_ipaddr = ipaddrs[0];
+            gnb_ipaddr = ipaddrs[1];
+            proxy_ipaddr = ipaddrs[2];
+
+            ue_ipaddr.resize(ipaddrs.size() - 3);
+            std::copy(ipaddrs.begin() + 3, ipaddrs.end(), ue_ipaddr.begin());
+        }
+        break;
     }
 
     remove_log_file();


### PR DESCRIPTION
1. Revised logic for checking number of provided IP addresses. Not providing IPs will still default to using the loopback address. (This default behavior still mirrors having one vector entry per UE).
2. The UE IP address variable is now a vector of strings to accommodate an indeterminate number of UEs.
3. When sending data downstream to the UE(s), the proxy now updates the socket struct address field along with the port field.
4. Added help field to README regarding multi-IP operation