### PR TITLE
Fix running with 3 IP addresses in args

### DIFF
--- a/src/proxy.cc
+++ b/src/proxy.cc
@@ -128,7 +128,7 @@ int main(int argc, char *argv[])
         enb_ipaddr = ipaddrs[0];
         gnb_ipaddr = ipaddrs[0];
         proxy_ipaddr = ipaddrs[1];
-        ue_ipaddr[0] = ipaddrs[2];
+        ue_ipaddr.push_back(ipaddrs[2]);
         break;
     case 4:
         if (softmodem_mode == SOFTMODEM_NSA)


### PR DESCRIPTION
This is a minor fix. ```ue_ipaddr``` was initialized with length 0, so accessing the first element results in a segmentation fault. Using ```push_back``` (like in every other case) resolves this issue.